### PR TITLE
Unpin jsonschema

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,6 @@ name = "pypi"
 
 [packages]
 pydantic = "*"
-jsonschema = ">=2.3, <4.0"
 "ga4gh.vrsatile.pydantic" = ">=0.0.5"
 "ga4gh.vrs" = {version = ">=0.7.2", extras = ["extras"]}
 "biocommons.seqrepo" = "*"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@
 
 -i https://pypi.org/simple
 -e .
-aiofiles==0.7.0; python_version < '4' and python_full_version >= '3.6.0'
+aiofiles==0.7.0; python_full_version >= '3.6.0' and python_full_version < '4.0.0'
 anyio==3.3.4; python_full_version >= '3.6.2'
 appdirs==1.4.4
 appnope==0.1.2; sys_platform == 'darwin'
@@ -34,7 +34,7 @@ charset-normalizer==2.0.7; python_version >= '3'
 click==8.0.3; python_full_version >= '3.6.0'
 coloredlogs==15.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 configparser==5.1.0; python_full_version >= '3.6.0'
-coverage[toml]==6.1.2
+coverage==6.1.2
 coveralls==3.3.1
 cssselect==1.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 debugpy==1.5.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
@@ -58,7 +58,7 @@ h11==0.12.0; python_full_version >= '3.6.0'
 hgvs==1.5.1
 humanfriendly==10.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 identify==2.3.7; python_full_version >= '3.6.1'
-idna==3.3; python_version >= '3'
+idna==3.3; python_version >= '3.5'
 importlib-metadata==4.8.2; python_version < '3.10'
 inflection==0.5.1; python_version >= '3.5'
 iniconfig==1.1.1
@@ -75,7 +75,7 @@ matplotlib-inline==0.1.3; python_version >= '3.5'
 mccabe==0.6.1
 nest-asyncio==1.5.1; python_version >= '3.5'
 nodeenv==1.6.0
-numpy==1.21.4; python_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64'
+numpy==1.21.4; python_version < '3.11' and python_version >= '3.7'
 packaging==21.3; python_version >= '3.6'
 pandas==1.3.4; python_full_version >= '3.7.1'
 parse==1.19.0
@@ -99,7 +99,7 @@ pyflakes==2.4.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.
 pygments==2.10.0; python_version >= '3.5'
 pyliftover==0.4
 pyparsing==3.0.6; python_version >= '3.6'
-pyppeteer==0.2.6; python_version < '4' and python_full_version >= '3.6.1'
+pyppeteer==0.2.6; python_full_version >= '3.6.1' and python_full_version < '4.0.0'
 pyquery==1.4.3
 pyrsistent==0.18.0; python_full_version >= '3.6.0'
 pysam==0.18.0
@@ -114,6 +114,7 @@ pyzmq==22.3.0; python_version >= '3.6'
 requests-html==0.10.0; python_full_version >= '3.6.0'
 requests==2.26.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 s3transfer==0.5.0; python_full_version >= '3.6.0'
+setuptools==59.1.1; python_full_version >= '3.6.0'
 simplejson==3.17.6; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sniffio==1.2.0; python_version >= '3.5'
@@ -128,7 +129,7 @@ tornado==6.1; python_version >= '3.5'
 tqdm==4.62.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 traitlets==5.1.1; python_version >= '3.7'
 typing-extensions==4.0.0; python_full_version >= '3.6.0'
-urllib3==1.26.7; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+urllib3==1.26.7; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'
 uta-tools==0.0.10
 uvicorn==0.15.0
 virtualenv==20.10.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 
 -i https://pypi.org/simple
-aiofiles==0.7.0; python_version < '4' and python_full_version >= '3.6.0'
+aiofiles==0.7.0; python_full_version >= '3.6.0' and python_full_version < '4.0.0'
 anyio==3.3.4; python_full_version >= '3.6.2'
 appdirs==1.4.4
 appnope==0.1.2; sys_platform == 'darwin'
@@ -40,7 +40,7 @@ gffutils==0.10.1
 h11==0.12.0; python_full_version >= '3.6.0'
 hgvs==1.5.1
 humanfriendly==10.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-idna==3.3; python_version >= '3'
+idna==3.3; python_version >= '3.5'
 importlib-metadata==4.8.2; python_version < '3.10'
 inflection==0.5.1; python_version >= '3.5'
 ipython==7.29.0; python_version >= '3.7'
@@ -50,7 +50,7 @@ jsonschema==3.2.0
 lxml==4.6.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
 markdown==3.3.6; python_full_version >= '3.6.0'
 matplotlib-inline==0.1.3; python_version >= '3.5'
-numpy==1.21.4; python_version < '3.10' and platform_machine != 'aarch64' and platform_machine != 'arm64'
+numpy==1.21.4; python_version < '3.11' and python_version >= '3.7'
 pandas==1.3.4; python_full_version >= '3.7.1'
 parse==1.19.0
 parsley==1.3
@@ -65,7 +65,7 @@ pyee==8.2.2
 pyfaidx==0.6.3.1
 pygments==2.10.0; python_version >= '3.5'
 pyliftover==0.4
-pyppeteer==0.2.6; python_version < '4' and python_full_version >= '3.6.1'
+pyppeteer==0.2.6; python_full_version >= '3.6.1' and python_full_version < '4.0.0'
 pyquery==1.4.3
 pyrsistent==0.18.0; python_full_version >= '3.6.0'
 pysam==0.18.0
@@ -76,6 +76,7 @@ pyyaml==6.0; python_full_version >= '3.6.0'
 requests-html==0.10.0; python_full_version >= '3.6.0'
 requests==2.26.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
 s3transfer==0.5.0; python_full_version >= '3.6.0'
+setuptools==59.1.1; python_full_version >= '3.6.0'
 simplejson==3.17.6; python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'
 six==1.16.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 sniffio==1.2.0; python_version >= '3.5'
@@ -86,7 +87,7 @@ tabulate==0.8.9
 tqdm==4.62.3; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 traitlets==5.1.1; python_version >= '3.7'
 typing-extensions==4.0.0; python_full_version >= '3.6.0'
-urllib3==1.26.7; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'
+urllib3==1.26.7; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_full_version < '4.0.0'
 uta-tools==0.0.10
 uvicorn==0.15.0
 w3lib==1.22.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ install_requires =
     pydantic
     ga4gh.vrsatile.pydantic >=0.0.5
     ga4gh.vrs[extras] >=0.7.2
-    jsonschema >=2.3, <4.0
     biocommons.seqrepo
     gene-normalizer >=0.1.23
     uta-tools >=0.0.10


### PR DESCRIPTION
* Unpin jsonschema.

VRS-Python is now updated to handle this dependency issue, so we should unpin here and use their requirements.