### PR TITLE
Fix: make type values consistent

### DIFF
--- a/examples/alk.json
+++ b/examples/alk.json
@@ -1,8 +1,9 @@
 {
+  "type": "Fusion",
   "functional_domains": [],
   "structural_components": [
     {
-      "component_type": "gene",
+      "type": "GeneComponent",
       "gene_descriptor": {
         "id": "normalize.gene:ALK",
         "type": "GeneDescriptor",
@@ -11,7 +12,7 @@
       }
     },
     {
-      "component_type": "any_gene"
+      "type": "AnyGeneComponent"
     }
   ],
   "regulatory_elements": []

--- a/examples/epcam_msh2.json
+++ b/examples/epcam_msh2.json
@@ -1,8 +1,9 @@
 {
+  "type": "Fusion",
   "functional_domains": [],
   "structural_components": [
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_002354.2",
       "exon_end": 5,
       "exon_end_offset": 0,
@@ -34,7 +35,7 @@
       }
     },
     {
-      "component_type": "linker_sequence",
+      "type": "LinkerSequenceComponent",
       "linker_sequence": {
         "id": "fusor.sequence:AGGCTCCCTTGG",
         "type": "SequenceDescriptor",
@@ -43,7 +44,7 @@
       }
     },
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_000251.2",
       "exon_start": 2,
       "exon_start_offset": 0,

--- a/examples/exhaustive_example.json
+++ b/examples/exhaustive_example.json
@@ -1,7 +1,9 @@
 {
+  "type": "Fusion",
   "r_frame_preserved": true,
   "functional_domains": [
     {
+      "type": "FunctionalDomain",
       "id": "interpro:IPR020635",
       "name": "Tyrosine-protein kinase, catalytic domain",
       "status": "lost",
@@ -81,7 +83,7 @@
   ],
   "structural_components": [
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_152263.3",
       "exon_start": 1,
       "exon_start_offset": 0,
@@ -209,7 +211,7 @@
       }
     },
     {
-      "component_type": "gene",
+      "type": "GeneComponent",
       "gene_descriptor": {
         "id": "normalize.gene:ALK",
         "type": "GeneDescriptor",
@@ -264,7 +266,7 @@
       }
     },
     {
-      "component_type": "linker_sequence",
+      "type": "LinkerSequenceComponent",
       "linker_sequence": {
         "id": "fusor.sequence:ACGT",
         "type": "SequenceDescriptor",
@@ -279,7 +281,7 @@
       }
     },
     {
-      "component_type": "templated_sequence",
+      "type": "TemplatedSequenceComponent",
       "region": {
         "id": "fusor.location_descriptor:NC_000001.11",
         "type": "LocationDescriptor",
@@ -302,13 +304,14 @@
       },
       "strand": "+"
     },
-    { "component_type": "unknown_gene" },
-    { "component_type": "any_gene" }
+    { "type": "UnknownGeneComponent" },
+    { "type": "AnyGeneComponent" }
   ],
   "causative_event": "rearrangement",
   "regulatory_elements": [
     {
-      "type": "promoter",
+      "type": "RegulatoryElement",
+      "element_type": "promoter",
       "gene_descriptor": {
         "id": "normalize.gene:BRAF",
         "type": "GeneDescriptor",

--- a/examples/minimal_example.json
+++ b/examples/minimal_example.json
@@ -1,7 +1,9 @@
 {
+  "type": "Fusion",
   "r_frame_preserved": true,
   "functional_domains": [
     {
+      "type": "FunctionalDomain",
       "id": "interpro:IPR020635",
       "name": "Tyrosine-protein kinase, catalytic domain",
       "status": "lost",
@@ -34,7 +36,7 @@
   ],
   "structural_components": [
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_152263.3",
       "exon_start": 1,
       "exon_start_offset": 0,
@@ -88,7 +90,7 @@
       }
     },
     {
-      "component_type": "gene",
+      "type": "GeneComponent",
       "gene_descriptor": {
         "id": "normalize.gene:ALK",
         "type": "GeneDescriptor",
@@ -97,7 +99,7 @@
       }
     },
     {
-      "component_type": "linker_sequence",
+      "type": "LinkerSequenceComponent",
       "linker_sequence": {
         "id": "fusor.sequence:ACGT",
         "type": "SequenceDescriptor",
@@ -106,7 +108,7 @@
       }
     },
     {
-      "component_type": "templated_sequence",
+      "type": "TemplatedSequenceComponent",
       "region": {
         "id": "fusor.location_descriptor:NC_000023.11",
         "type": "LocationDescriptor",
@@ -130,16 +132,17 @@
       "strand": "+"
     },
     {
-      "component_type": "unknown_gene"
+      "type": "UnknownGeneComponent"
     },
     {
-      "component_type": "any_gene"
+      "type": "AnyGeneComponent"
     }
   ],
   "causative_event": "rearrangement",
   "regulatory_elements": [
     {
-      "type": "promoter",
+      "type": "RegulatoryElement",
+      "element_type": "promoter",
       "gene_descriptor": {
         "id": "gene:BRAF",
         "type": "GeneDescriptor",

--- a/examples/tpm3_ntrk1.json
+++ b/examples/tpm3_ntrk1.json
@@ -1,7 +1,9 @@
 {
+  "type": "Fusion",
   "r_frame_preserved": true,
   "functional_domains": [
     {
+      "type": "FunctionalDomain",
       "id": "interpro:IPR000533",
       "name": "Tropomyosin",
       "status": "preserved",
@@ -32,6 +34,7 @@
       }
     },
     {
+      "type": "FunctionalDomain",
       "id": "interpro:IPR020635",
       "name": "Tyrosine-protein kinase, catalytic domain",
       "status": "preserved",
@@ -64,7 +67,7 @@
   ],
   "structural_components": [
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_152263.3",
       "exon_end": 8,
       "exon_end_offset": 0,
@@ -96,7 +99,7 @@
       }
     },
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_002529.3",
       "exon_start": 10,
       "exon_start_offset": 0,

--- a/examples/tpm3_pdgfrb.json
+++ b/examples/tpm3_pdgfrb.json
@@ -1,8 +1,9 @@
 {
+  "type": "Fusion",
   "functional_domains": [],
   "structural_components": [
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_152263.3",
       "exon_end": 8,
       "exon_end_offset": 0,
@@ -34,7 +35,7 @@
       }
     },
     {
-      "component_type": "transcript_segment",
+      "type": "TranscriptSegmentComponent",
       "transcript": "refseq:NM_002609.3",
       "exon_start": 11,
       "exon_start_offset": 0,

--- a/fusor/fusor.py
+++ b/fusor/fusor.py
@@ -20,7 +20,7 @@ from fusor.models import Fusion, TemplatedSequenceComponent, \
     AdditionalFields, TranscriptSegmentComponent, GeneComponent, \
     LinkerComponent, UnknownGeneComponent, AnyGeneComponent, \
     RegulatoryElement, Event, DomainStatus, FunctionalDomain, Strand, \
-    RegulatoryElementType, ComponentType
+    RegulatoryElementType, FUSORTypes
 from fusor.exceptions import IDTranslationException
 
 
@@ -342,7 +342,7 @@ class FUSOR:
 
         try:
             return RegulatoryElement(
-                type=element_type,
+                element_type=element_type,
                 gene_descriptor=gene_descr
             ), None
         except ValidationError as e:
@@ -610,17 +610,17 @@ class FUSOR:
         """
         nom_parts = []
         for component in fusion.structural_components:
-            if component.component_type == ComponentType.ANY_GENE:
+            if component.type == FUSORTypes.ANY_GENE_COMPONENT:
                 nom_parts.append("*")
-            elif component.component_type == ComponentType.UNKNOWN_GENE:
+            elif component.type == FUSORTypes.UNKNOWN_GENE_COMPONENT:
                 nom_parts.append("?")
-            elif component.component_type == ComponentType.GENE:
+            elif component.type == FUSORTypes.GENE_COMPONENT:
                 label = component.gene_descriptor.label
                 gene_id = component.gene_descriptor.gene_id
                 nom_parts.append(f"{label}({gene_id})")
-            elif component.component_type == ComponentType.LINKER_SEQUENCE:
+            elif component.type == FUSORTypes.LINKER_SEQUENCE_COMPONENT:
                 nom_parts.append(component.linker_sequence.sequence)
-            elif component.component_type == ComponentType.TRANSCRIPT_SEGMENT:
+            elif component.type == FUSORTypes.TRANSCRIPT_SEGMENT_COMPONENT:
                 tx = component.transcript.split(":")[1]
                 label = component.gene_descriptor.label
                 comp_name = f"{tx}({label}):e."
@@ -640,7 +640,7 @@ class FUSOR:
                         else:
                             comp_name += str(component.exon_end_offset)
                 nom_parts.append(comp_name)
-            elif component.component_type == ComponentType.TEMPLATED_SEQUENCE:
+            elif component.type == FUSORTypes.TEMPLATED_SEQUENCE_COMPONENT:
                 loc = component.region.location
                 start = loc.interval.start.value
                 end = loc.interval.end.value

--- a/fusor/models.py
+++ b/fusor/models.py
@@ -10,6 +10,20 @@ from ga4gh.vrsatile.pydantic.vrsatile_models import GeneDescriptor, \
 from ga4gh.vrsatile.pydantic.vrs_models import Sequence
 
 
+class FUSORTypes(str, Enum):
+    """Define FUSOR object type values."""
+
+    FUNCTIONAL_DOMAIN = "FunctionalDomain"
+    TRANSCRIPT_SEGMENT_COMPONENT = "TranscriptSegmentComponent"
+    TEMPLATED_SEQUENCE_COMPONENT = "TemplatedSequenceComponent"
+    LINKER_SEQUENCE_COMPONENT = "LinkerSequenceComponent"
+    GENE_COMPONENT = "GeneComponent"
+    UNKNOWN_GENE_COMPONENT = "UnknownGeneComponent"
+    ANY_GENE_COMPONENT = "AnyGeneComponent"
+    REGULATORY_ELEMENT = "RegulatoryElement"
+    FUSION = "Fusion"
+
+
 class AdditionalFields(str, Enum):
     """Define possible fields that can be added to Fusion object."""
 
@@ -28,6 +42,7 @@ class DomainStatus(str, Enum):
 class FunctionalDomain(BaseModel):
     """Define FunctionalDomain class"""
 
+    type: Literal[FUSORTypes.FUNCTIONAL_DOMAIN] = FUSORTypes.FUNCTIONAL_DOMAIN
     id: CURIE
     name: StrictStr
     status: DomainStatus
@@ -49,6 +64,7 @@ class FunctionalDomain(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
+                "type": "FunctionalDomain",
                 "status": "lost",
                 "name": "Tyrosine-protein kinase, catalytic domain",
                 "id": "interpro:IPR020635",
@@ -79,21 +95,10 @@ class FunctionalDomain(BaseModel):
             }
 
 
-class ComponentType(str, Enum):
-    """Define possible structural components."""
-
-    TRANSCRIPT_SEGMENT = "transcript_segment"
-    TEMPLATED_SEQUENCE = "templated_sequence"
-    LINKER_SEQUENCE = "linker_sequence"
-    GENE = "gene"
-    UNKNOWN_GENE = "unknown_gene"
-    ANY_GENE = "any_gene"
-
-
 class TranscriptSegmentComponent(BaseModel):
     """Define TranscriptSegment class"""
 
-    component_type: Literal[ComponentType.TRANSCRIPT_SEGMENT] = ComponentType.TRANSCRIPT_SEGMENT  # noqa: E501
+    type: Literal[FUSORTypes.TRANSCRIPT_SEGMENT_COMPONENT] = FUSORTypes.TRANSCRIPT_SEGMENT_COMPONENT  # noqa: E501
     transcript: CURIE
     exon_start: Optional[StrictInt]
     exon_start_offset: Optional[StrictInt] = 0
@@ -143,13 +148,14 @@ class TranscriptSegmentComponent(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
-                "component_type": "transcript_segment",
+                "type": "TranscriptSegmentComponent",
                 "transcript": "refseq:NM_152263.3",
                 "exon_start": 1,
                 "exon_start_offset": 0,
                 "exon_end": 8,
                 "exon_end_offset": 0,
                 "gene_descriptor": {
+                    "type": "GeneDescriptor",
                     "id": "gene:TPM3",
                     "gene_id": "hgnc:12012",
                     "type": "GeneDescriptor",
@@ -201,7 +207,7 @@ class TranscriptSegmentComponent(BaseModel):
 class LinkerComponent(BaseModel):
     """Define Linker class (linker sequence)"""
 
-    component_type: Literal[ComponentType.LINKER_SEQUENCE] = ComponentType.LINKER_SEQUENCE  # noqa: E501
+    type: Literal[FUSORTypes.LINKER_SEQUENCE_COMPONENT] = FUSORTypes.LINKER_SEQUENCE_COMPONENT  # noqa: E501
     linker_sequence: SequenceDescriptor
 
     @validator("linker_sequence", pre=True)
@@ -239,7 +245,7 @@ class LinkerComponent(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
-                "component_type": "linker_sequence",
+                "type": "LinkerSequenceComponent",
                 "linker_sequence": {
                     "id": "sequence:ACGT",
                     "type": "SequenceDescriptor",
@@ -262,7 +268,7 @@ class TemplatedSequenceComponent(BaseModel):
     gene product
     """
 
-    component_type: Literal[ComponentType.TEMPLATED_SEQUENCE] = ComponentType.TEMPLATED_SEQUENCE  # noqa: E501
+    type: Literal[FUSORTypes.TEMPLATED_SEQUENCE_COMPONENT] = FUSORTypes.TEMPLATED_SEQUENCE_COMPONENT  # noqa: E501
     region: LocationDescriptor
     strand: Strand
 
@@ -281,7 +287,7 @@ class TemplatedSequenceComponent(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
-                "component_type": "templated_sequence",
+                "type": "TemplatedSequenceComponent",
                 "region": {
                     "id": "chr12:44908821-44908822(+)",
                     "type": "LocationDescriptor",
@@ -304,7 +310,7 @@ class TemplatedSequenceComponent(BaseModel):
 class GeneComponent(BaseModel):
     """Define Gene component class."""
 
-    component_type: Literal[ComponentType.GENE] = ComponentType.GENE
+    type: Literal[FUSORTypes.GENE_COMPONENT] = FUSORTypes.GENE_COMPONENT
     gene_descriptor: GeneDescriptor
 
     class Config:
@@ -320,7 +326,7 @@ class GeneComponent(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
-                "component_type": "gene",
+                "type": "GeneComponent",
                 "gene_descriptor": {
                     "id": "gene:BRAF",
                     "gene_id": "hgnc:1097",
@@ -340,7 +346,7 @@ class UnknownGeneComponent(BaseModel):
     an UnknownGene component.
     """
 
-    component_type: Literal[ComponentType.UNKNOWN_GENE] = ComponentType.UNKNOWN_GENE  # noqa: E501
+    type: Literal[FUSORTypes.UNKNOWN_GENE_COMPONENT] = FUSORTypes.UNKNOWN_GENE_COMPONENT  # noqa: E501
 
     class Config:
         """Configure class."""
@@ -355,7 +361,7 @@ class UnknownGeneComponent(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
-                "component_type": "unknown_gene"
+                "type": "UnknownGeneComponent"
             }
 
 
@@ -370,7 +376,7 @@ class AnyGeneComponent(BaseModel):
     AnyGene component.
     """
 
-    component_type: Literal[ComponentType.ANY_GENE] = ComponentType.ANY_GENE
+    type: Literal[FUSORTypes.ANY_GENE_COMPONENT] = FUSORTypes.ANY_GENE_COMPONENT  # noqa: E501
 
     class Config:
         """Configure class."""
@@ -385,7 +391,7 @@ class AnyGeneComponent(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
-                "component_type": "any_gene"
+                "type": "AnyGeneComponent"
             }
 
 
@@ -407,7 +413,8 @@ class RegulatoryElementType(str, Enum):
 class RegulatoryElement(BaseModel):
     """Define RegulatoryElement class"""
 
-    type: RegulatoryElementType
+    type: Literal[FUSORTypes.REGULATORY_ELEMENT] = FUSORTypes.REGULATORY_ELEMENT  # noqa: E501
+    element_type: RegulatoryElementType
     gene_descriptor: GeneDescriptor
 
     class Config:
@@ -423,7 +430,8 @@ class RegulatoryElement(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
-                "type": "promoter",
+                "type": "RegulatoryElement",
+                "element_type": "Promoter",
                 "gene_descriptor": {
                     "id": "gene:BRAF",
                     "gene_id": "hgnc:1097",
@@ -436,6 +444,7 @@ class RegulatoryElement(BaseModel):
 class Fusion(BaseModel):
     """Define Fusion class"""
 
+    type: Literal[FUSORTypes.FUSION] = FUSORTypes.FUSION
     r_frame_preserved: Optional[StrictBool]
     functional_domains: Optional[List[FunctionalDomain]]
     structural_components: List[Union[TranscriptSegmentComponent,
@@ -469,6 +478,7 @@ class Fusion(BaseModel):
             for prop in schema.get("properties", {}).values():
                 prop.pop("title", None)
             schema["example"] = {
+                "type": "Fusion",
                 "r_frame_preserved": True,
                 "functional_domains": [
                     {
@@ -485,7 +495,7 @@ class Fusion(BaseModel):
                 ],
                 "structural_components": [
                     {
-                        "component_type": "transcript_segment",
+                        "component_type": "TranscriptSegment",
                         "transcript": "refseq:NM_152263.3",
                         "exon_start": 1,
                         "exon_start_offset": 0,
@@ -551,7 +561,7 @@ class Fusion(BaseModel):
                 "causative_event": "rearrangement",
                 "regulatory_elements": [
                     {
-                        "type": "promoter",
+                        "element_type": "promoter",
                         "gene": {
                             "id": "gene:BRAF",
                             "type": "GeneDescriptor",

--- a/tests/test_fusor.py
+++ b/tests/test_fusor.py
@@ -108,7 +108,7 @@ def linker_component():
             "residue_type": "SO:0000348",
             "type": "SequenceDescriptor"
         },
-        "component_type": "linker_sequence"
+        "type": "LinkerSequenceComponent"
     }
     return LinkerComponent(**params)
 
@@ -206,7 +206,7 @@ def functional_domain_seq_id(braf_gene_descr_min,
 def regulatory_element(braf_gene_descr):
     """Create regulatory element test fixture."""
     params = {
-        "type": "promoter",
+        "element_type": "promoter",
         "gene_descriptor": braf_gene_descr
     }
     return RegulatoryElement(**params)
@@ -216,7 +216,7 @@ def regulatory_element(braf_gene_descr):
 def regulatory_element_min(braf_gene_descr_min):
     """Create regulatory element test fixture with minimal gene descriptor."""
     params = {
-        "type": "promoter",
+        "element_type": "promoter",
         "gene_descriptor": braf_gene_descr_min
     }
     return RegulatoryElement(**params)
@@ -251,7 +251,7 @@ def location_descriptor_tpm3():
 def templated_sequence_component():
     """Create test fixture for templated sequence component"""
     params = {
-        "component_type": "templated_sequence",
+        "type": "TemplatedSequenceComponent",
         "region": {
             "id": "fusor.location_descriptor:NC_000001.11",
             "type": "LocationDescriptor",
@@ -280,7 +280,7 @@ def templated_sequence_component():
 def templated_sequence_component_ensg():
     """Create test fixture using non-seqrepo-recognized sequence ID"""
     params = {
-        "component_type": "templated_sequence",
+        "type": "TemplatedSequenceComponent",
         "region": {
             "id": "fusor.location_descriptor:ENSG00000157764",
             "type": "LocationDescriptor",
@@ -311,7 +311,7 @@ def templated_sequence_component_custom_id():
     sequence identifier.
     """
     params = {
-        "component_type": "templated_sequence",
+        "type": "TemplatedSequenceComponent",
         "region": {
             "id": "fusor.location_descriptor:custom_ID__1",
             "type": "LocationDescriptor",
@@ -340,7 +340,7 @@ def templated_sequence_component_custom_id():
 def transcript_segment_component():
     """Create transcript segment component test fixture"""
     params = {
-        "component_type": "transcript_segment",
+        "type": "TranscriptSegmentComponent",
         "exon_end": 8,
         "exon_end_offset": 0,
         "exon_start": 1,
@@ -388,7 +388,7 @@ def transcript_segment_component():
 def mane_transcript_segment_component():
     """Create transcript segment component test fixture"""
     params = {
-        "component_type": "transcript_segment",
+        "type": "TranscriptSegmentComponent",
         "exon_end": None,
         "exon_end_offset": None,
         "exon_start": 2,
@@ -456,7 +456,7 @@ def fusion():
         ],
         "structural_components": [
             {
-                "component_type": "transcript_segment",
+                "type": "TranscriptSegmentComponent",
                 "transcript": "refseq:NM_152263.3",
                 "exon_start": 1,
                 "exon_start_offset": 0,
@@ -508,7 +508,7 @@ def fusion():
                 }
             },
             {
-                "component_type": "gene",
+                "type": "GeneComponent",
                 "gene_descriptor": {
                     "id": "gene:ALK",
                     "type": "GeneDescriptor",
@@ -517,7 +517,7 @@ def fusion():
                 }
             },
             {
-                "component_type": "linker_sequence",
+                "type": "LinkerSequenceComponent",
                 "linker_sequence": {
                     "id": "sequence:ACGT",
                     "type": "SequenceDescriptor",
@@ -526,7 +526,7 @@ def fusion():
                 }
             },
             {
-                "component_type": "templated_sequence",
+                "type": "TemplatedSequenceComponent",
                 "region": {
                     "id": "chr12:44908821-44908822(+)",
                     "type": "LocationDescriptor",
@@ -550,16 +550,16 @@ def fusion():
                 "strand": "+"
             },
             {
-                "component_type": "unknown_gene"
+                "type": "UnknownGeneComponent"
             },
             {
-                "component_type": "any_gene"
+                "type": "AnyGeneComponent"
             }
         ],
         "causative_event": "rearrangement",
         "regulatory_elements": [
             {
-                "type": "promoter",
+                "element_type": "promoter",
                 "gene_descriptor": {
                     "id": "gene:BRAF",
                     "type": "GeneDescriptor",
@@ -577,7 +577,7 @@ def fusion_ensg_sequence_id(templated_sequence_component_ensg):
     params = {
         "structural_components": [
             templated_sequence_component_ensg,
-            {"component_type": "any_gene"}
+            {"type": "AnyGeneComponent"}
         ],
         "r_frame_preserved": True,
         "functional_domains": [],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -182,6 +182,7 @@ def functional_domains(gene_descriptors, location_descriptors):
     """Provide possible functional_domains input."""
     return [
         {
+            "type": "FunctionalDomain",
             "status": "preserved",
             "name": "WW domain",
             "id": "interpro:IPR001202",
@@ -213,7 +214,7 @@ def transcript_segments(location_descriptors, gene_descriptors):
             "component_genomic_end": location_descriptors[3]
         },
         {
-            "component_type": "transcript_segment",
+            "type": "TranscriptSegmentComponent",
             "transcript": "refseq:NM_034348.3",
             "exon_start": 1,
             "exon_end": 8,
@@ -222,7 +223,7 @@ def transcript_segments(location_descriptors, gene_descriptors):
             "component_genomic_end": location_descriptors[1]
         },
         {
-            "component_type": "transcript_segment",
+            "type": "TranscriptSegmentComponent",
             "transcript": "refseq:NM_938439.4",
             "exon_start": 7,
             "exon_end": 14,
@@ -232,7 +233,7 @@ def transcript_segments(location_descriptors, gene_descriptors):
             "component_genomic_end": location_descriptors[1]
         },
         {
-            "component_type": "transcript_segment",
+            "type": "TranscriptSegmentComponent",
             "transcript": "refseq:NM_938439.4",
             "exon_start": 7,
             "gene_descriptor": gene_descriptors[4],
@@ -246,7 +247,7 @@ def gene_components(gene_descriptors):
     """Provide possible gene component input data."""
     return [
         {
-            "component_type": "gene",
+            "type": "GeneComponent",
             "gene_descriptor": gene_descriptors[1],
         }
     ]
@@ -257,12 +258,12 @@ def templated_sequence_components(location_descriptors):
     """Provide possible templated sequence component input data."""
     return [
         {
-            "component_type": "templated_sequence",
+            "type": "TemplatedSequenceComponent",
             "strand": "+",
             "region": location_descriptors[5]
         },
         {
-            "component_type": "templated_sequence",
+            "type": "TemplatedSequenceComponent",
             "strand": "-",
             "region": location_descriptors[4]
         }
@@ -299,15 +300,15 @@ def linkers(sequence_descriptors):
     """Provide possible linker component input data."""
     return [
         {
-            "component_type": "linker_sequence",
+            "type": "LinkerSequenceComponent",
             "linker_sequence": sequence_descriptors[0]
         },
         {
-            "component_type": "linker_sequence",
+            "type": "LinkerSequenceComponent",
             "linker_sequence": sequence_descriptors[1]
         },
         {
-            "component_type": "linker_sequence",
+            "type": "LinkerSequenceComponent",
             "linker_sequence": sequence_descriptors[2]
         }
     ]
@@ -318,7 +319,7 @@ def regulatory_elements(gene_descriptors):
     """Provide possible regulatory_element input data."""
     return [
         {
-            "type": "promoter",
+            "element_type": "promoter",
             "gene_descriptor": gene_descriptors[0]
         }
     ]
@@ -339,6 +340,7 @@ def check_validation_error(exc_info, expected_msg: str,
 def test_functional_domain(functional_domains, gene_descriptors):
     """Test FunctionalDomain object initializes correctly"""
     test_domain = FunctionalDomain(**functional_domains[0])
+    assert test_domain.type == "FunctionalDomain"
     assert test_domain.status == "preserved"
     assert test_domain.name == "WW domain"
     assert test_domain.id == "interpro:IPR001202"
@@ -354,6 +356,7 @@ def test_functional_domain(functional_domains, gene_descriptors):
     assert test_loc.location.interval.end.value == 204
 
     test_domain = FunctionalDomain(**functional_domains[1])
+    assert test_domain.type == "FunctionalDomain"
     assert test_domain.status == "lost"
     assert test_domain.name == "Tyrosine-protein kinase, catalytic domain"
     assert test_domain.id == "interpro:IPR020635"
@@ -454,7 +457,7 @@ def test_transcript_segment_component(transcript_segments):
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert TranscriptSegmentComponent(**{
-            "component_type": "templated_sequence",
+            "type": "TemplatedSequenceComponent",
             "transcript": "NM_152263.3",
             "exon_start": "1",
             "exon_start_offset": "-9",
@@ -478,7 +481,7 @@ def test_transcript_segment_component(transcript_segments):
                 }
             }
         })
-    msg = "unexpected value; permitted: <ComponentType.TRANSCRIPT_SEGMENT: 'transcript_segment'>"  # noqa: E501
+    msg = "unexpected value; permitted: <FUSORTypes.TRANSCRIPT_SEGMENT_COMPONENT: 'TranscriptSegmentComponent'>"  # noqa: E501
     check_validation_error(exc_info, msg)
 
     # test component required
@@ -500,7 +503,7 @@ def test_transcript_segment_component(transcript_segments):
     # Neither exon_start or exon_end given
     with pytest.raises(ValidationError) as exc_info:
         assert TranscriptSegmentComponent(**{
-            "component_type": "templated_sequence",
+            "type": "TranscriptSegmentComponent",
             "transcript": "NM_152263.3",
             "exon_start_offset": "-9",
             "exon_end_offset": "7",
@@ -529,7 +532,7 @@ def test_transcript_segment_component(transcript_segments):
 def test_linker_component(linkers):
     """Test Linker object initializes correctly"""
     def check_linker(actual, expected_id, expected_sequence):
-        assert actual.component_type == "linker_sequence"
+        assert actual.type == "LinkerSequenceComponent"
         assert actual.linker_sequence.id == expected_id
         assert actual.linker_sequence.sequence == expected_sequence
         assert actual.linker_sequence.type == "SequenceDescriptor"
@@ -555,20 +558,20 @@ def test_linker_component(linkers):
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert LinkerComponent(**{
-            "component_type": "templated_sequence",
+            "type": "TemplatedSequenceComponent",
             "linker_sequence":
             {
                 "id": "sequence:ATG",
                 "sequence": "ATG"
             }
         })
-    msg = "unexpected value; permitted: <ComponentType.LINKER_SEQUENCE: 'linker_sequence'>"  # noqa: E501
+    msg = "unexpected value; permitted: <FUSORTypes.LINKER_SEQUENCE_COMPONENT: 'LinkerSequenceComponent'>"  # noqa: E501
     check_validation_error(exc_info, msg)
 
     # test no extras
     with pytest.raises(ValidationError) as exc_info:
         assert LinkerComponent(**{
-            "component_type": "linker_sequence",
+            "type": "LinkerSequenceComponent",
             "linker_sequence": {
                 "id": "sequence:G",
                 "sequence": "G"
@@ -586,7 +589,7 @@ def test_genomic_region_component(templated_sequence_components,
         """Assert that test templated_sequence_components[0] data matches
         expected values.
         """
-        assert test.component_type == "templated_sequence"
+        assert test.type == "TemplatedSequenceComponent"
         assert test.strand.value == "+"
         assert test.region.id == "chr12:p12.1-p12.2"
         assert test.region.type == "LocationDescriptor"
@@ -630,18 +633,18 @@ def test_genomic_region_component(templated_sequence_components,
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert TemplatedSequenceComponent(**{
-            "component_type": "gene",
+            "type": "GeneComponent",
             "region": location_descriptors[0],
             "strand": "+"
         })
-    msg = "unexpected value; permitted: <ComponentType.TEMPLATED_SEQUENCE: 'templated_sequence'>"  # noqa: E501
+    msg = "unexpected value; permitted: <FUSORTypes.TEMPLATED_SEQUENCE_COMPONENT: 'TemplatedSequenceComponent'>"  # noqa: E501
     check_validation_error(exc_info, msg)
 
 
 def test_gene_component(gene_descriptors):
     """Test that Gene component initializes correctly."""
     test_component = GeneComponent(**{"gene_descriptor": gene_descriptors[0]})
-    assert test_component.component_type == "gene"
+    assert test_component.type == "GeneComponent"
     assert test_component.gene_descriptor.id == "gene:G1"
     assert test_component.gene_descriptor.label == "G1"
     assert test_component.gene_descriptor.gene.gene_id == "hgnc:9339"
@@ -661,34 +664,34 @@ def test_gene_component(gene_descriptors):
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert GeneComponent(**{
-            "component_type": "unknown_gene",
+            "type": "UnknownGeneComponent",
             "gene_descriptor": gene_descriptors[0]
         })
-    msg = "unexpected value; permitted: <ComponentType.GENE: 'gene'>"
+    msg = "unexpected value; permitted: <FUSORTypes.GENE_COMPONENT: 'GeneComponent'>"  # noqa: E501
     check_validation_error(exc_info, msg)
 
 
 def test_unknown_gene_component():
     """Test that unknown_gene component initializes correctly."""
     test_component = UnknownGeneComponent()
-    assert test_component.component_type == "unknown_gene"
+    assert test_component.type == "UnknownGeneComponent"
 
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
-        assert UnknownGeneComponent(component_type="gene")
-    msg = "unexpected value; permitted: <ComponentType.UNKNOWN_GENE: 'unknown_gene'>"  # noqa: E501
+        assert UnknownGeneComponent(type="gene")
+    msg = "unexpected value; permitted: <FUSORTypes.UNKNOWN_GENE_COMPONENT: 'UnknownGeneComponent'>"  # noqa: E501
     check_validation_error(exc_info, msg)
 
 
 def test_any_gene_component():
     """Test that any_gene component initializes correctly."""
     test_component = AnyGeneComponent()
-    assert test_component.component_type == "any_gene"
+    assert test_component.type == "AnyGeneComponent"
 
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
-        assert AnyGeneComponent(component_type="unknown_gene")
-    msg = "unexpected value; permitted: <ComponentType.ANY_GENE: 'any_gene'>"
+        assert AnyGeneComponent(type="unknown_gene")
+    msg = "unexpected value; permitted: <FUSORTypes.ANY_GENE_COMPONENT: 'AnyGeneComponent'>"  # noqa: E501
     check_validation_error(exc_info, msg)
 
 
@@ -705,7 +708,7 @@ def test_event():
 def test_regulatory_element(regulatory_elements, gene_descriptors):
     """Test RegulatoryElement object initializes correctly"""
     test_reg_elmt = RegulatoryElement(**regulatory_elements[0])
-    assert test_reg_elmt.type.value == "promoter"
+    assert test_reg_elmt.element_type.value == "promoter"
     assert test_reg_elmt.gene_descriptor.id == "gene:G1"
     assert test_reg_elmt.gene_descriptor.gene.gene_id == "hgnc:9339"
     assert test_reg_elmt.gene_descriptor.label == "G1"
@@ -713,7 +716,7 @@ def test_regulatory_element(regulatory_elements, gene_descriptors):
     # check type constraint
     with pytest.raises(ValidationError) as exc_info:
         RegulatoryElement(**{
-            "type": "notpromoter",
+            "element_type": "notpromoter",
             "gene": gene_descriptors[0]
         })
     msg = "value is not a valid enumeration member; permitted: 'promoter', 'enhancer'"  # noqa: E501
@@ -725,7 +728,7 @@ def test_fusion(functional_domains, transcript_segments,
                 regulatory_elements):
     """Test that Fusion object initializes correctly"""
     unknown_component = {
-        "component_type": "unknown_gene",
+        "type": "UnknownGeneComponent",
     }
 
     # test valid object
@@ -745,7 +748,7 @@ def test_fusion(functional_domains, transcript_segments,
     fusion = Fusion(**{
         "structural_components": [
             {
-                "component_type": "gene",
+                "type": "GeneComponent",
                 "gene_descriptor": {
                     "type": "GeneDescriptor",
                     "id": "gene:NTRK1",
@@ -754,7 +757,7 @@ def test_fusion(functional_domains, transcript_segments,
                 }
             },
             {
-                "component_type": "gene",
+                "type": "GeneComponent",
                 "gene_descriptor": {
                     "type": "GeneDescriptor",
                     "id": "gene:ABL1",
@@ -765,9 +768,9 @@ def test_fusion(functional_domains, transcript_segments,
         ],
         "regulatory_elements": []
     })
-    assert fusion.structural_components[0].component_type == "gene"
+    assert fusion.structural_components[0].type == "GeneComponent"
     assert fusion.structural_components[0].gene_descriptor.id == "gene:NTRK1"
-    assert fusion.structural_components[1].component_type == "gene"
+    assert fusion.structural_components[1].type == "GeneComponent"
     assert fusion.structural_components[1].gene_descriptor.type == "GeneDescriptor"  # noqa: E501
 
     # test that non-component properties are optional
@@ -790,7 +793,7 @@ def test_fusion(functional_domains, transcript_segments,
     assert Fusion(**{
         "structural_components": [
             {
-                "component_type": "linker_sequence",
+                "type": "LinkerSequenceComponent",
                 "linker_sequence": {
                     "id": "a:b",
                     "type": "SequenceDescriptor",
@@ -799,7 +802,7 @@ def test_fusion(functional_domains, transcript_segments,
                 }
             },
             {
-                "component_type": "linker_sequence",
+                "type": "LinkerSequenceComponent",
                 "linker_sequence": {
                     "id": "a:b",
                     "type": "SequenceDescriptor",
@@ -829,13 +832,15 @@ def test_fusion(functional_domains, transcript_segments,
     check_validation_error(exc_info, msg)
 
 
-def test_examples(exhaustive_example):
+def test_examples(exhaustive_example, fusion_example):
     """Test example JSON files."""
     assert Fusion(**exhaustive_example)
 
+    assert Fusion(**fusion_example)
+
     for example in [
-            "alk.json", "epcam_msh2.json", "exhaustive_example.json",
-            "tpm3_ntrk1.json", "tpm3_pdgfrb.json"
+            "alk.json", "epcam_msh2.json", "tpm3_ntrk1.json",
+            "tpm3_pdgfrb.json"
     ]:
         with open(EXAMPLES_DIR / example, "r") as example_file:
             example = json.load(example_file)


### PR DESCRIPTION
Partially out of thoughtlessness and laziness, I'd been leaving type values out of some objects and had used inconsistent naming/case patterns. This updates FUSOR objects to be consistent with Pascal Case (as used in VRS/VRSATILE) and ensures that type values are given for all objects.