### PR TITLE
fix: junction nomenclature to remove additional _

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,6 +4,6 @@
 * `exhaustive_example.json`: Above fusion, but with GA4GH sequence ID and location ID values, and expanded gene descriptors provided by the [VICC gene normalizer](https://github.com/cancervariants/gene-normalization). Nomenclature representation is unchanged.
 * `alk.json`: Example of an ALK fusion retrieved from a human-curated database like [CIViC](https://civicdb.org/events/genes/1/summary/variants/552/summary#variant). Represented in nomenclature as `ALK(hgnc:427)::v`.
 * `ewsr1.json`: An EWSR1 assayed fusion. Represented in nomenclature as `EWSR1(hgnc:3508)::?`.
-* `tpm3_ntrk1.json`: Example TPM3-NTRK1 fusion drawn from previous VICC Fusion Curation draft material. Represented in nomenclature as `refseq:NM_152263.3(TPM3):e._8::refseq:NM_002529.3(NTRK1):e.10_`.
-* `epcam_msh2.json`: Example EPCAM-MSH2 fusion. Represented in nomenclature as `refseq:NM_002354.2(EPCAM):e._5::AGGCTCCCTTGG::refseq:NM_000251.2(MSH2):e.2_`.
-* `tpm3_pdgfrb.json`: Example fusion TPM3 fusion. Represented in nomenclature as `refseq:NM_152263.3(TPM3):e._8::refseq:NM_002609.3(PDGFRB):e.11_`.
+* `tpm3_ntrk1.json`: Example TPM3-NTRK1 fusion drawn from previous VICC Fusion Curation draft material. Represented in nomenclature as `refseq:NM_152263.3(TPM3):e.8::refseq:NM_002529.3(NTRK1):e.10`.
+* `epcam_msh2.json`: Example EPCAM-MSH2 fusion. Represented in nomenclature as `refseq:NM_002354.2(EPCAM):e.5::AGGCTCCCTTGG::refseq:NM_000251.2(MSH2):e.2`.
+* `tpm3_pdgfrb.json`: Example fusion TPM3 fusion. Represented in nomenclature as `refseq:NM_152263.3(TPM3):e.8::refseq:NM_002609.3(PDGFRB):e.11`.

--- a/fusor/nomenclature.py
+++ b/fusor/nomenclature.py
@@ -68,7 +68,7 @@ def tx_segment_nomenclature(element: TranscriptSegmentElement,
         end = element.exon_end
         if element.exon_end_offset:
             end_offset = element.exon_end_offset
-    return f"{prefix}:e.{start}{start_offset}_{end}{end_offset}"
+    return f"{prefix}:e.{start}{start_offset}{'_' if start and end else ''}{end}{end_offset}"  # noqa: E501
 
 
 def templated_seq_nomenclature(element: TemplatedSequenceElement,

--- a/fusor/version.py
+++ b/fusor/version.py
@@ -1,2 +1,2 @@
 """Define library version."""
-__version__ = "0.0.20"
+__version__ = "0.0.21"

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -68,17 +68,17 @@ def test_generate_nomenclature(fusor, fusion, fusion_example,
     with open(EXAMPLES_DIR / "epcam_msh2.json", "r") as epcam_file:
         fusion = CategoricalFusion(**json.load(epcam_file))
     nm = fusor.generate_nomenclature(fusion)
-    assert nm == "refseq:NM_002354.2(EPCAM):e._5::AGGCTCCCTTGG::refseq:NM_000251.2(MSH2):e.2_"  # noqa: E501
+    assert nm == "refseq:NM_002354.2(EPCAM):e.5::AGGCTCCCTTGG::refseq:NM_000251.2(MSH2):e.2"  # noqa: E501
 
     with open(EXAMPLES_DIR / "tpm3_ntrk1.json", "r") as ntrk_file:
         fusion = AssayedFusion(**json.load(ntrk_file))
     nm = fusor.generate_nomenclature(fusion)
-    assert nm == "refseq:NM_152263.3(TPM3):e._8::refseq:NM_002529.3(NTRK1):e.10_"  # noqa: E501
+    assert nm == "refseq:NM_152263.3(TPM3):e.8::refseq:NM_002529.3(NTRK1):e.10"  # noqa: E501
 
     with open(EXAMPLES_DIR / "tpm3_pdgfrb.json", "r") as pdgfrb_file:
         fusion = CategoricalFusion(**json.load(pdgfrb_file))
     nm = fusor.generate_nomenclature(fusion)
-    assert nm == "refseq:NM_152263.3(TPM3):e._8::refseq:NM_002609.3(PDGFRB):e.11_"  # noqa: E501
+    assert nm == "refseq:NM_152263.3(TPM3):e.8::refseq:NM_002609.3(PDGFRB):e.11"  # noqa: E501
 
     with open(EXAMPLES_DIR / "ewsr1.json", "r") as ewsr1_file:
         fusion = AssayedFusion(**json.load(ewsr1_file))


### PR DESCRIPTION
closes #90 

Nomenclature [here](https://fusions.cancervariants.org/en/draft-1/nomenclature.html?highlight=junction#junction-components) 