### PR TITLE
fix: catch alternate gene descriptor structure

### DIFF
--- a/fusor/models.py
+++ b/fusor/models.py
@@ -552,10 +552,15 @@ class AbstractFusion(BaseModel, ABC):
         """
         gene_descriptor = cls._access_object_attr(obj, gene_descriptor_field)
         if gene_descriptor:
-            gene = cls._access_object_attr(gene_descriptor, "gene")
-            if gene:
-                gene_id = cls._access_object_attr(gene, "gene_id")
+            gene_value = cls._access_object_attr(gene_descriptor, "gene")
+            if gene_value:
+                gene_id = cls._access_object_attr(gene_value, "gene_id")
+                if gene_id:
+                    return gene_id
+            gene_id = cls._access_object_attr(gene_descriptor, "gene_id")
+            if gene_id:
                 return gene_id
+        return None
 
     @root_validator(pre=True)
     def enforce_abc(cls, values):

--- a/fusor/version.py
+++ b/fusor/version.py
@@ -1,2 +1,2 @@
 """Define library version."""
-__version__ = "0.0.28-dev0"
+__version__ = "0.0.28-dev1"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -36,6 +36,13 @@ def gene_descriptors():
             "label": "ALK",
         },
         {"id": "gene:YAP1", "gene_id": "hgnc:16262", "label": "YAP1"},
+        # alternate structure
+        {
+            "id": "normalize.gene:BRAF",
+            "type": "GeneDescriptor",
+            "label": "BRAF",
+            "gene_id": "hgnc:1097",
+        },
     ]
 
 
@@ -213,6 +220,7 @@ def gene_elements(gene_descriptors):
             "gene_descriptor": gene_descriptors[1],
         },
         {"type": "GeneElement", "gene_descriptor": gene_descriptors[0]},
+        {"type"},
     ]
 
 
@@ -817,6 +825,7 @@ def test_fusion_element_count(
     unknown_element,
     gene_elements,
     transcript_segments,
+    gene_descriptors,
 ):
     """Test fusion element count requirements."""
     # elements are mandatory
@@ -877,6 +886,55 @@ def test_fusion_element_count(
             }
         )
     check_validation_error(exc_info, uq_gene_error_msg)
+
+    # use alternate gene descriptor structure
+    with pytest.raises(ValidationError) as exc_info:
+        assert AssayedFusion(
+            **{
+                "type": "AssayedFusion",
+                "structural_elements": [
+                    {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
+                    {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
+                ],
+                "causative_event": {
+                    "type": "CausativeEvent",
+                    "event_type": "read-through",
+                },
+                "assay": {
+                    "type": "Assay",
+                    "method_uri": "pmid:33576979",
+                    "assay_id": "obi:OBI_0003094",
+                    "assay_name": "fluorescence in-situ hybridization assay",
+                    "fusion_detection": "inferred",
+                },
+            }
+        )
+    with pytest.raises(ValidationError) as exc_info:
+        assert AssayedFusion(
+            **{
+                "type": "AssayedFusion",
+                "structural_elements": [
+                    {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
+                ],
+                "regulatory_element": {
+                    "type": "RegulatoryElement",
+                    "regulatory_class": "enhancer",
+                    "feature_id": "EH111111111",
+                    "associated_gene": gene_descriptors[6],
+                },
+                "causative_event": {
+                    "type": "CausativeEvent",
+                    "event_type": "read-through",
+                },
+                "assay": {
+                    "type": "Assay",
+                    "method_uri": "pmid:33576979",
+                    "assay_id": "obi:OBI_0003094",
+                    "assay_name": "fluorescence in-situ hybridization assay",
+                    "fusion_detection": "inferred",
+                },
+            }
+        )
 
 
 def test_fusion_abstraction_validator(transcript_segments, linkers):


### PR DESCRIPTION
VRSATILE technically allows two different JSON structures for defining gene concept IDs, this catches the second way for the "must have multiple genes" model validation