### PR TITLE
feat: relax requirements on minimum information model

### DIFF
--- a/fusor/examples/__init__.py
+++ b/fusor/examples/__init__.py
@@ -18,6 +18,12 @@ with open(EXAMPLES_DIR / "bcr_abl1_expanded.json") as f:
 with open(EXAMPLES_DIR / "ewsr1.json") as f:
     ewsr1 = AssayedFusion(**json.load(f))
 
+with open(EXAMPLES_DIR / "ewsr1_no_assay.json") as f:
+    ewsr1_no_assay = AssayedFusion(**json.load(f))
+
+with open(EXAMPLES_DIR / "ewsr1_no_causative_event.json") as f:
+    ewsr1_no_causative_event = AssayedFusion(**json.load(f))
+
 with open(EXAMPLES_DIR / "igh_myc.json") as f:
     igh_myc = CategoricalFusion(**json.load(f))
 

--- a/fusor/examples/__init__.py
+++ b/fusor/examples/__init__.py
@@ -24,6 +24,9 @@ with open(EXAMPLES_DIR / "ewsr1_no_assay.json") as f:
 with open(EXAMPLES_DIR / "ewsr1_no_causative_event.json") as f:
     ewsr1_no_causative_event = AssayedFusion(**json.load(f))
 
+with open(EXAMPLES_DIR / "ewsr1_elements_only.json") as f:
+    ewsr1_elements_only = AssayedFusion(**json.load(f))
+
 with open(EXAMPLES_DIR / "igh_myc.json") as f:
     igh_myc = CategoricalFusion(**json.load(f))
 

--- a/fusor/examples/ewsr1_elements_only.json
+++ b/fusor/examples/ewsr1_elements_only.json
@@ -1,0 +1,17 @@
+{
+  "type": "AssayedFusion",
+  "structural_elements": [
+    {
+      "type": "GeneElement",
+      "gene_descriptor": {
+        "type": "GeneDescriptor",
+        "id": "normalize.gene:EWSR1",
+        "label": "EWSR1",
+        "gene_id": "hgnc:3508"
+      }
+    },
+    {
+      "type": "UnknownGeneElement"
+    }
+  ]
+}

--- a/fusor/examples/ewsr1_no_assay.json
+++ b/fusor/examples/ewsr1_no_assay.json
@@ -1,0 +1,21 @@
+{
+  "type": "AssayedFusion",
+  "structural_elements": [
+    {
+      "type": "GeneElement",
+      "gene_descriptor": {
+        "type": "GeneDescriptor",
+        "id": "normalize.gene:EWSR1",
+        "label": "EWSR1",
+        "gene_id": "hgnc:3508"
+      }
+    },
+    {
+      "type": "UnknownGeneElement"
+    }
+  ],
+  "causative_event": {
+    "type": "CausativeEvent",
+    "event_type": "rearrangement"
+  }
+}

--- a/fusor/examples/ewsr1_no_causative_event.json
+++ b/fusor/examples/ewsr1_no_causative_event.json
@@ -1,0 +1,24 @@
+{
+  "type": "AssayedFusion",
+  "structural_elements": [
+    {
+      "type": "GeneElement",
+      "gene_descriptor": {
+        "type": "GeneDescriptor",
+        "id": "normalize.gene:EWSR1",
+        "label": "EWSR1",
+        "gene_id": "hgnc:3508"
+      }
+    },
+    {
+      "type": "UnknownGeneElement"
+    }
+  ],
+  "assay": {
+    "type": "Assay",
+    "method_uri": "pmid:33576979",
+    "assay_id": "obi:OBI_0003094",
+    "assay_name": "fluorescence in-situ hybridization assay",
+    "fusion_detection": "inferred"
+  }
+}

--- a/fusor/fusor.py
+++ b/fusor/fusor.py
@@ -808,7 +808,8 @@ class FUSOR:
             else:
                 raise ValueError
         if (
-            isinstance(fusion, AssayedFusion) and fusion.assay
+            isinstance(fusion, AssayedFusion)
+            and fusion.assay
             and fusion.assay.fusion_detection == Evidence.INFERRED
         ):
             divider = "(::)"

--- a/fusor/fusor.py
+++ b/fusor/fusor.py
@@ -194,15 +194,15 @@ class FUSOR:
     @staticmethod
     def assayed_fusion(
         structural_elements: AssayedFusionElements,
-        causative_event: CausativeEvent,
-        assay: Assay,
+        causative_event: Optional[CausativeEvent] = None,
+        assay: Optional[Assay] = None,
         regulatory_element: Optional[RegulatoryElement] = None,
     ) -> AssayedFusion:
         """Construct an assayed fusion object
         :param AssayedFusionElements structural_elements: elements constituting the
             fusion
-        :param Event causative_event: event causing the fusion
-        :param Assay assay: how knowledge of the fusion was obtained
+        :param Optional[Event] causative_event: event causing the fusion
+        :param Optional[Assay] assay: how knowledge of the fusion was obtained
         :param Optional[RegulatoryElement] regulatory_element: affected regulatory
             elements
         :return: Tuple containing optional AssayedFusion if construction successful,

--- a/fusor/fusor.py
+++ b/fusor/fusor.py
@@ -808,7 +808,7 @@ class FUSOR:
             else:
                 raise ValueError
         if (
-            isinstance(fusion, AssayedFusion)
+            isinstance(fusion, AssayedFusion) and fusion.assay
             and fusion.assay.fusion_detection == Evidence.INFERRED
         ):
             divider = "(::)"

--- a/fusor/models.py
+++ b/fusor/models.py
@@ -725,8 +725,8 @@ class AssayedFusion(AbstractFusion):
 
     type: Literal[FUSORTypes.ASSAYED_FUSION] = FUSORTypes.ASSAYED_FUSION
     structural_elements: AssayedFusionElements
-    causative_event: CausativeEvent
-    assay: Assay
+    causative_event: Optional[CausativeEvent] = None
+    assay: Optional[Assay] = None
 
     class Config(BaseModelForbidExtra.Config):
         """Configure class."""

--- a/fusor/models.py
+++ b/fusor/models.py
@@ -646,10 +646,10 @@ class Assay(BaseModelForbidExtra):
     """Information pertaining to the assay used in identifying the fusion."""
 
     type: Literal["Assay"] = "Assay"
-    assay_name: StrictStr
-    assay_id: CURIE
-    method_uri: CURIE
-    fusion_detection: Evidence
+    assay_name: Optional[StrictStr]
+    assay_id: Optional[CURIE]
+    method_uri: Optional[CURIE]
+    fusion_detection: Optional[Evidence]
 
     _get_assay_id_val = validator("assay_id", allow_reuse=True)(return_value)
     _get_method_uri_val = validator("method_uri", allow_reuse=True)(return_value)

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -273,6 +273,9 @@ def test_generate_nomenclature(
     nm = fusor_instance.generate_nomenclature(examples.ewsr1_no_causative_event)
     assert nm == "EWSR1(hgnc:3508)(::)?"
 
+    nm = fusor_instance.generate_nomenclature(examples.ewsr1_elements_only)
+    assert nm == "EWSR1(hgnc:3508)::?"
+
     nm = fusor_instance.generate_nomenclature(examples.igh_myc)
     assert nm == "reg_e_EH38E3121735@IGH(hgnc:5477)::MYC(hgnc:7553)"
 

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -267,6 +267,12 @@ def test_generate_nomenclature(
     nm = fusor_instance.generate_nomenclature(examples.ewsr1)
     assert nm == "EWSR1(hgnc:3508)(::)?"
 
+    nm = fusor_instance.generate_nomenclature(examples.ewsr1_no_assay)
+    assert nm == "EWSR1(hgnc:3508)::?"
+
+    nm = fusor_instance.generate_nomenclature(examples.ewsr1_no_causative_event)
+    assert nm == "EWSR1(hgnc:3508)(::)?"
+
     nm = fusor_instance.generate_nomenclature(examples.igh_myc)
     assert nm == "reg_e_EH38E3121735@IGH(hgnc:5477)::MYC(hgnc:7553)"
 


### PR DESCRIPTION
in my original PR, I did not address an issue where in nomenclature generation, the fusion's assay is assumed to always exist, so this would result in fusor throwing an exception when no assay is provided. 

In this PR, I added some short circuiting logic to avoid that exception being thrown and also added unit tests to check for proper nomenclature generation when assay or causative event are not provided.