### PR TITLE
style: use ruff for formatting

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,8 +6,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: black
-        uses: psf/black@stable
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
 
-      - name: ruff
-        uses: chartboost/ruff-action@v1
+      - name: Install dependencies
+        run: python3 -m pip install ".[dev]"
+
+      - name: Check style
+        run: python3 -m ruff check . && ruff format --check .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,9 @@ repos:
       - id: detect-private-key
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  - repo: https://github.com/psf/black
-    rev: 23.7.0
-    hooks:
-      - id: black
-        language_version: python3.11
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.0.280
+    rev: v0.1.14
     hooks:
+      - id: ruff-format
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/fusor/__init__.py
+++ b/fusor/__init__.py
@@ -3,7 +3,7 @@ import logging
 from os import environ
 from pathlib import Path
 
-from .version import __version__  # noqa: F401
+from .version import __version__
 
 logging.basicConfig(
     filename="fusor.log",
@@ -13,10 +13,7 @@ logger = logging.getLogger("fusor")
 logger.setLevel(logging.DEBUG)
 
 
-if "SEQREPO_DATA_PATH" in environ:
-    SEQREPO_DATA_PATH = environ["SEQREPO_DATA_PATH"]
-else:
-    SEQREPO_DATA_PATH = "/usr/local/share/seqrepo/latest"
+SEQREPO_DATA_PATH = environ.get("SEQREPO_DATA_PATH", "/usr/local/share/seqrepo/latest")
 
 if "UTA_DB_URL" in environ:
     UTA_DB_URL = environ["UTA_DB_URL"]
@@ -29,6 +26,6 @@ logging.getLogger("nose").setLevel(logging.INFO)
 logging.getLogger("python_jsonschema_objects.classbuilder").setLevel(logging.INFO)
 logging.getLogger("urllib3").setLevel(logging.INFO)
 
-from fusor.fusor import FUSOR  # noqa: E402, F401
+from fusor.fusor import FUSOR  # noqa: E402
 
 APP_ROOT = Path(__file__).resolve().parents[0]

--- a/fusor/examples/__init__.py
+++ b/fusor/examples/__init__.py
@@ -6,32 +6,32 @@ from fusor.models import AssayedFusion, CategoricalFusion
 
 EXAMPLES_DIR = APP_ROOT / "examples"
 
-with open(EXAMPLES_DIR / "alk.json") as f:
+with (EXAMPLES_DIR / "alk.json").open() as f:
     alk = CategoricalFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "bcr_abl1.json") as f:
+with (EXAMPLES_DIR / "bcr_abl1.json").open() as f:
     bcr_abl1 = CategoricalFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "bcr_abl1_expanded.json") as f:
+with (EXAMPLES_DIR / "bcr_abl1_expanded.json").open() as f:
     bcr_abl1_expanded = CategoricalFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "ewsr1.json") as f:
+with (EXAMPLES_DIR / "ewsr1.json").open() as f:
     ewsr1 = AssayedFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "ewsr1_no_assay.json") as f:
+with (EXAMPLES_DIR / "ewsr1_no_assay.json").open() as f:
     ewsr1_no_assay = AssayedFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "ewsr1_no_causative_event.json") as f:
+with (EXAMPLES_DIR / "ewsr1_no_causative_event.json").open() as f:
     ewsr1_no_causative_event = AssayedFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "ewsr1_elements_only.json") as f:
+with (EXAMPLES_DIR / "ewsr1_elements_only.json").open() as f:
     ewsr1_elements_only = AssayedFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "igh_myc.json") as f:
+with (EXAMPLES_DIR / "igh_myc.json").open() as f:
     igh_myc = CategoricalFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "tpm3_ntrk1.json") as f:
+with (EXAMPLES_DIR / "tpm3_ntrk1.json").open() as f:
     tpm3_ntrk1 = AssayedFusion(**json.load(f))
 
-with open(EXAMPLES_DIR / "tpm3_pdgfrb.json") as f:
+with (EXAMPLES_DIR / "tpm3_pdgfrb.json").open() as f:
     tpm3_pdgfrb = AssayedFusion(**json.load(f))

--- a/fusor/exceptions.py
+++ b/fusor/exceptions.py
@@ -4,10 +4,6 @@
 class IDTranslationException(Exception):  # noqa: N818
     """Indicate translation failure for provided ID value"""
 
-    pass
-
 
 class FUSORParametersException(Exception):  # noqa: N818
     """Signal incorrect or insufficient parameters for model constructor methods."""
-
-    pass

--- a/fusor/fusor.py
+++ b/fusor/fusor.py
@@ -381,7 +381,8 @@ class FUSOR:
 
     @staticmethod
     def linker_element(
-        sequence: str, residue_type: CURIE = "SO:0000348"  # type: ignore
+        sequence: str,
+        residue_type: CURIE = "SO:0000348",  # type: ignore
     ) -> Tuple[Optional[LinkerElement], Optional[str]]:
         """Create linker element
 

--- a/fusor/fusor.py
+++ b/fusor/fusor.py
@@ -89,9 +89,9 @@ class FUSOR:
         False otherwise.
         """
         for c in kwargs["structural_elements"]:
-            if isinstance(c, Dict) and c.get("type") == elm_type:
-                return True
-            elif isinstance(c, BaseStructuralElement) and c.type == elm_type:
+            if (isinstance(c, Dict) and c.get("type") == elm_type) or (
+                isinstance(c, BaseStructuralElement) and c.type == elm_type
+            ):
                 return True
         return False
 
@@ -112,9 +112,8 @@ class FUSOR:
                 fusion_type = explicit_type
                 kwargs.pop("type")
             else:
-                raise FUSORParametersException(
-                    f"Invalid type parameter: {explicit_type}"
-                )
+                msg = f"Invalid type parameter: {explicit_type}"
+                raise FUSORParametersException(msg)
         fusion_fn = None
         if fusion_type:
             if fusion_type == FusionType.CATEGORICAL_FUSION:
@@ -122,9 +121,8 @@ class FUSOR:
             elif fusion_type == FusionType.ASSAYED_FUSION:
                 fusion_fn = self.assayed_fusion
             else:
-                raise FUSORParametersException(
-                    f"Invalid fusion_type parameter: {fusion_type}"
-                )
+                msg = f"Invalid fusion_type parameter: {fusion_type}"
+                raise FUSORParametersException(msg)
         else:
             # try to infer from provided attributes
             categorical_attributes = any(
@@ -146,19 +144,20 @@ class FUSOR:
                 ]
             )
             if categorical_attributes and assayed_attributes:
-                raise FUSORParametersException("Received conflicting attributes")
-            elif categorical_attributes and not assayed_attributes:
+                msg = "Received conflicting attributes"
+                raise FUSORParametersException(msg)
+            if categorical_attributes and not assayed_attributes:
                 fusion_fn = self.categorical_fusion
             elif assayed_attributes and not categorical_attributes:
                 fusion_fn = self.assayed_fusion
         if fusion_fn is None:
-            raise FUSORParametersException("Unable to determine fusion type")
+            msg = "Unable to determine fusion type"
+            raise FUSORParametersException(msg)
         try:
             return fusion_fn(**kwargs)
         except TypeError as e:
-            raise FUSORParametersException(
-                f"Unable to construct fusion with provided args: {e}"
-            )
+            msg = f"Unable to construct fusion with provided args: {e}"
+            raise FUSORParametersException(msg) from e
 
     @staticmethod
     def categorical_fusion(
@@ -187,7 +186,7 @@ class FUSOR:
                 regulatory_element=regulatory_element,
             )
         except ValidationError as e:
-            raise FUSORParametersException(str(e))
+            raise FUSORParametersException(str(e)) from e
         return fusion
 
     @staticmethod
@@ -215,7 +214,7 @@ class FUSOR:
                 assay=assay,
             )
         except ValidationError as e:
-            raise FUSORParametersException(str(e))
+            raise FUSORParametersException(str(e)) from e
         return fusion
 
     async def transcript_segment_element(
@@ -332,8 +331,7 @@ class FUSOR:
         )
         if not gene_descr:
             return None, warning
-        else:
-            return GeneElement(gene_descriptor=gene_descr), None
+        return GeneElement(gene_descriptor=gene_descr), None
 
     def templated_sequence_element(
         self,
@@ -382,7 +380,7 @@ class FUSOR:
     @staticmethod
     def linker_element(
         sequence: str,
-        residue_type: CURIE = "SO:0000348",  # type: ignore
+        residue_type: CURIE = "SO:0000348",
     ) -> Tuple[Optional[LinkerElement], Optional[str]]:
         """Create linker element
 
@@ -736,7 +734,7 @@ class FUSOR:
 
         for prop in properties:
             for obj in prop:
-                if "gene_descriptor" in obj.model_fields.keys():
+                if "gene_descriptor" in obj.model_fields:
                     label = obj.gene_descriptor.label
                     norm_gene_descr, _ = self._normalized_gene_descriptor(
                         label, use_minimal_gene_descr=False
@@ -773,8 +771,7 @@ class FUSOR:
                     id=gene_descr.id, gene_id=gene_descr.gene_id, label=gene_descr.label
                 )
             return gene_descr, None
-        else:
-            return None, f"gene-normalizer unable to normalize {query}"
+        return None, f"gene-normalizer unable to normalize {query}"
 
     def generate_nomenclature(self, fusion: Fusion) -> str:
         """Generate human-readable nomenclature describing provided fusion
@@ -797,14 +794,14 @@ class FUSOR:
                 parts.append(element.linker_sequence.sequence)
             elif isinstance(element, TranscriptSegmentElement):
                 if not any(
-                    [gene == element.gene_descriptor.label for gene in element_genes]
+                    [gene == element.gene_descriptor.label for gene in element_genes]  # noqa: C419
                 ):
                     parts.append(tx_segment_nomenclature(element))
             elif isinstance(element, TemplatedSequenceElement):
                 parts.append(templated_seq_nomenclature(element, self.seqrepo))
             elif isinstance(element, GeneElement):
                 if not any(
-                    [gene == element.gene_descriptor.label for gene in element_genes]
+                    [gene == element.gene_descriptor.label for gene in element_genes]  # noqa: C419
                 ):
                     parts.append(gene_nomenclature(element))
             else:

--- a/fusor/models.py
+++ b/fusor/models.py
@@ -448,7 +448,7 @@ class AbstractFusion(BaseModel, ABC):
     def _access_object_attr(
         cls: Type[FusionType],
         obj: Union[Dict, BaseModel],
-        attr_name: str,  # noqa: ANN102
+        attr_name: str,
     ) -> Optional[Any]:  # noqa: ANN401
         """Help enable safe access of object properties while performing
         validation for Pydantic class objects. Because the validator could be handling either
@@ -477,7 +477,7 @@ class AbstractFusion(BaseModel, ABC):
     def _fetch_gene_id(
         cls: Type[FusionType],
         obj: Union[Dict, BaseModel],
-        gene_descriptor_field: str,  # noqa: ANN102
+        gene_descriptor_field: str,
     ) -> Optional[str]:
         """Get gene ID if element includes a gene annotation.
 
@@ -526,7 +526,7 @@ class AbstractFusion(BaseModel, ABC):
         if (num_structural_elements + bool(reg_element)) < 2:
             raise ValueError(qt_error_msg)
 
-        uq_gene_msg = "Fusions must form a chimeric transcript from two or more genes, or a novel interaction between a rearranged regulatory element with the expressed product of a partner gene."  # noqa: E501
+        uq_gene_msg = "Fusions must form a chimeric transcript from two or more genes, or a novel interaction between a rearranged regulatory element with the expressed product of a partner gene."
         gene_ids = []
         if reg_element:
             gene_id = cls._fetch_gene_id(
@@ -647,7 +647,7 @@ class CausativeEvent(BaseModelForbidExtra):
             "example": {
                 "type": "CausativeEvent",
                 "event_type": "rearrangement",
-                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",  # noqa: E501
+                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
             }
         },
     )
@@ -672,7 +672,7 @@ class AssayedFusion(AbstractFusion):
                 "causative_event": {
                     "type": "CausativeEvent",
                     "event_type": "rearrangement",
-                    "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",  # noqa: E501
+                    "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
                 },
                 "assay": {
                     "type": "Assay",
@@ -759,7 +759,7 @@ class CategoricalFusion(AbstractFusion):
                             "type": "LocationDescriptor",
                             "location_id": "ga4gh:VSL.vyyyExx4enSZdWZr3z67-T8uVKH50uLi",
                             "location": {
-                                "sequence_id": "ga4gh:SQ.ijXOSP3XSsuLWZhXQ7_TJ5JXu4RJO6VT",  # noqa: E501
+                                "sequence_id": "ga4gh:SQ.ijXOSP3XSsuLWZhXQ7_TJ5JXu4RJO6VT",
                                 "type": "SequenceLocation",
                                 "interval": {
                                     "start": {"type": "Number", "value": 154192135},
@@ -773,7 +773,7 @@ class CategoricalFusion(AbstractFusion):
                             "type": "LocationDescriptor",
                             "location_id": "ga4gh:VSL._1bRdL4I6EtpBvVK5RUaXb0NN3k0gpqa",
                             "location": {
-                                "sequence_id": "ga4gh:SQ.ijXOSP3XSsuLWZhXQ7_TJ5JXu4RJO6VT",  # noqa: E501
+                                "sequence_id": "ga4gh:SQ.ijXOSP3XSsuLWZhXQ7_TJ5JXu4RJO6VT",
                                 "type": "SequenceLocation",
                                 "interval": {
                                     "start": {"type": "Number", "value": 154170398},

--- a/fusor/nomenclature.py
+++ b/fusor/nomenclature.py
@@ -37,10 +37,10 @@ def reg_element_nomenclature(element: RegulatoryElement, sr: SeqRepo) -> str:
         sequence_id = start.location.sequence_id
         refseq_id = str(translate_identifier(sr, sequence_id, "refseq")).split(":")[1]
         try:
-            chr = str(translate_identifier(sr, sequence_id, "GRCh38")).split(":")[1]
-        except IDTranslationException:
-            raise ValueError
-        feature_string += f"_{refseq_id}(chr {chr}):g.{start.location.interval.start.value}_{start.location.interval.end.value}"
+            chrom = str(translate_identifier(sr, sequence_id, "GRCh38")).split(":")[1]
+        except IDTranslationException as e:
+            raise ValueError from e
+        feature_string += f"_{refseq_id}(chr {chrom}):g.{start.location.interval.start.value}_{start.location.interval.end.value}"
     if element.associated_gene:
         if element.associated_gene.gene_id:
             gene_id = gene_id = element.associated_gene.gene_id
@@ -102,14 +102,14 @@ def templated_seq_nomenclature(element: TemplatedSequenceElement, sr: SeqRepo) -
             start = location.interval.start.value
             end = location.interval.end.value
             try:
-                chr = str(translate_identifier(sr, sequence_id, "GRCh38")).split(":")[1]
-            except IDTranslationException:
-                raise ValueError
-            return f"{refseq_id.split(':')[1]}(chr {chr}):g.{start}_{end}({element.strand.value})"
-        else:
-            raise ValueError
-    else:
+                chrom = str(translate_identifier(sr, sequence_id, "GRCh38")).split(":")[
+                    1
+                ]
+            except IDTranslationException as e:
+                raise ValueError from e
+            return f"{refseq_id.split(':')[1]}(chr {chrom}):g.{start}_{end}({element.strand.value})"
         raise ValueError
+    raise ValueError
 
 
 def gene_nomenclature(element: GeneElement) -> str:

--- a/fusor/nomenclature.py
+++ b/fusor/nomenclature.py
@@ -40,7 +40,7 @@ def reg_element_nomenclature(element: RegulatoryElement, sr: SeqRepo) -> str:
             chr = str(translate_identifier(sr, sequence_id, "GRCh38")).split(":")[1]
         except IDTranslationException:
             raise ValueError
-        feature_string += f"_{refseq_id}(chr {chr}):g.{start.location.interval.start.value}_{start.location.interval.end.value}"  # noqa: E501
+        feature_string += f"_{refseq_id}(chr {chr}):g.{start.location.interval.start.value}_{start.location.interval.end.value}"
     if element.associated_gene:
         if element.associated_gene.gene_id:
             gene_id = gene_id = element.associated_gene.gene_id
@@ -84,7 +84,7 @@ def tx_segment_nomenclature(element: TranscriptSegmentElement) -> str:
             end_offset = str(element.exon_end_offset)
     else:
         end_offset = ""
-    return f"{prefix}:e.{start}{start_offset}{'_' if start and end else ''}{end}{end_offset}"  # noqa: E501
+    return f"{prefix}:e.{start}{start_offset}{'_' if start and end else ''}{end}{end_offset}"
 
 
 def templated_seq_nomenclature(element: TemplatedSequenceElement, sr: SeqRepo) -> str:
@@ -105,7 +105,7 @@ def templated_seq_nomenclature(element: TemplatedSequenceElement, sr: SeqRepo) -
                 chr = str(translate_identifier(sr, sequence_id, "GRCh38")).split(":")[1]
             except IDTranslationException:
                 raise ValueError
-            return f"{refseq_id.split(':')[1]}(chr {chr}):g.{start}_{end}({element.strand.value})"  # noqa: E501
+            return f"{refseq_id.split(':')[1]}(chr {chr}):g.{start}_{end}({element.strand.value})"
         else:
             raise ValueError
     else:

--- a/fusor/tools.py
+++ b/fusor/tools.py
@@ -23,9 +23,8 @@ def translate_identifier(
         )
     except KeyError as e:
         logger.warning(f"Unable to get translated identifier: {e}")
-        raise IDTranslationException
+        raise IDTranslationException from e
 
-    if target_ids:
-        return target_ids[0]
-    else:
+    if not target_ids:
         raise IDTranslationException
+    return target_ids[0]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,49 @@ build-backend = "setuptools.build_meta"
 
 [tool.ruff]
 src = ["fusor"]
-# pycodestyle (E, W)
-# Pyflakes (F)
-# flake8-annotations (ANN)
-# pydocstyle (D)
-# pep8-naming (N)
-# isort (I)
-select = ["E", "W", "F", "ANN", "D", "N", "I"]
-fixable = ["I", "F401"]
-
+select = [
+    "F",  # https://docs.astral.sh/ruff/rules/#pyflakes-f
+    "E", "W",  # https://docs.astral.sh/ruff/rules/#pycodestyle-e-w
+    "I",  # https://docs.astral.sh/ruff/rules/#isort-i
+    "N",  # https://docs.astral.sh/ruff/rules/#pep8-naming-n
+    "D",  # https://docs.astral.sh/ruff/rules/#pydocstyle-d
+    "UP",  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+    "ANN",  # https://docs.astral.sh/ruff/rules/#flake8-annotations-ann
+    "ASYNC",  # https://docs.astral.sh/ruff/rules/#flake8-async-async
+    "S",  # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
+    "B",  # https://docs.astral.sh/ruff/rules/#flake8-bugbear-b
+    "A",  # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "C4",  # https://docs.astral.sh/ruff/rules/#flake8-comprehensions-c4
+    "DTZ",  # https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz
+    "T10",  # https://docs.astral.sh/ruff/rules/#flake8-datetimez-dtz
+    "EM",  # https://docs.astral.sh/ruff/rules/#flake8-errmsg-em
+    "G",  # https://docs.astral.sh/ruff/rules/#flake8-logging-format-g
+    "PIE",  # https://docs.astral.sh/ruff/rules/#flake8-pie-pie
+    "T20",  # https://docs.astral.sh/ruff/rules/#flake8-print-t20
+    "PT",  # https://docs.astral.sh/ruff/rules/#flake8-pytest-style-pt
+    "Q",  # https://docs.astral.sh/ruff/rules/#flake8-quotes-q
+    "RSE",  # https://docs.astral.sh/ruff/rules/#flake8-raise-rse
+    "RET",  # https://docs.astral.sh/ruff/rules/#flake8-return-ret
+    "SIM",  # https://docs.astral.sh/ruff/rules/#flake8-simplify-sim
+    "PTH",  # https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth
+    "PGH",  # https://docs.astral.sh/ruff/rules/#pygrep-hooks-pgh
+    "RUF",  # https://docs.astral.sh/ruff/rules/#ruff-specific-rules-ruf
+]
+fixable = [
+    "I",
+    "F401",
+    "D",
+    "UP",
+    "ANN",
+    "B",
+    "C4",
+    "G",
+    "PIE",
+    "PT",
+    "RSE",
+    "SIM",
+    "RUF"
+]
 # ANN101 - missing-type-self
 # ANN003 - missing-type-kwargs
 # D203 - one-blank-line-before-class
@@ -42,7 +76,8 @@ ignore = [
 # N805 - invalid-first-argument-name-for-method
 # F821 - undefined-name
 # F401 - unused-import
-"tests/*" = ["ANN001", "ANN2", "ANN102"]
-"setup.py" = ["F821"]
+# S101 - assert
+"tests/*" = ["ANN001", "ANN2", "ANN102", "S101"]
+"setup.py" = ["F821", "S102", "SIM115", "PTH123"]  # temporary -- remove in #136
 "*__init__.py" = ["F401"]
 "fusor/models.py" = ["ANN201", "N805", "ANN001", "ANN2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,31 +2,38 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-line-length = 88
-
 [tool.ruff]
+src = ["src"]
 # pycodestyle (E, W)
 # Pyflakes (F)
 # flake8-annotations (ANN)
-# flake8-quotes (Q)
 # pydocstyle (D)
 # pep8-naming (N)
 # isort (I)
-select = ["E", "W", "F", "ANN", "Q", "D", "N", "I"]
+select = ["E", "W", "F", "ANN", "D", "N", "I"]
+fixable = ["I", "F401"]
 
-fixable = ["I"]
-
-# D205 - blank-line-after-summary
-# D400 - ends-in-period
-# D415 - ends-in-punctuation
 # ANN101 - missing-type-self
 # ANN003 - missing-type-kwargs
-# E501 - line-too-long
-ignore = ["D205", "D400", "D415", "ANN101", "ANN003", "E501"]
-
-[tool.ruff.flake8-quotes]
-docstring-quotes = "double"
+# D203 - one-blank-line-before-class
+# D205 - blank-line-after-summary
+# D206 - indent-with-spaces*
+# D213 - multi-line-summary-second-line
+# D300 - triple-single-quotes*
+# D400 - ends-in-period
+# D415 - ends-in-punctuation
+# E111 - indentation-with-invalid-multiple*
+# E114 - indentation-with-invalid-multiple-comment*
+# E117 - over-indented*
+# E501 - line-too-long*
+# W191 - tab-indentation*
+# *ignored for compatibility with formatter
+ignore = [
+    "ANN101", "ANN003",
+    "D203", "D205", "D206", "D213", "D300", "D400", "D415",
+    "E111", "E114", "E117", "E501",
+    "W191"
+]
 
 [tool.ruff.per-file-ignores]
 # ANN001 - missing-type-function-argument

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [tool.ruff]
-src = ["src"]
+src = ["fusor"]
 # pycodestyle (E, W)
 # Pyflakes (F)
 # flake8-annotations (ANN)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,8 +52,7 @@ dev =
     pytest
     pytest-cov
     pytest-asyncio
-    black
-    ruff
+    ruff>=0.1.14
 
 
 [tool:pytest]

--- a/setup.py
+++ b/setup.py
@@ -2,4 +2,4 @@
 from setuptools import setup
 
 exec(open("fusor/version.py").read())
-setup(version=__version__)  # noqa: F821
+setup(version=__version__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 """Module containing methods and fixtures used throughout tests."""
 import pytest
+
 from fusor.fusor import FUSOR
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -523,7 +523,7 @@ def exhaustive_example(alk_gene_descriptor, braf_gene_descriptor):
     }
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture()
 def fusion_example():
     """Create test fixture for a fake fusion without additional property expansion."""
     return {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 """Module containing methods and fixtures used throughout tests."""
 import pytest
-
 from fusor.fusor import FUSOR
 
 
@@ -344,7 +343,7 @@ def exhaustive_example(alk_gene_descriptor, braf_gene_descriptor):
                                 {
                                     "_id": "ga4gh:VSL._ASa2-iBSDZSpC3JlpwJxzv4OY5M-5Ct",
                                     "type": "SequenceLocation",
-                                    "sequence_id": "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",  # noqa: E501
+                                    "sequence_id": "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
                                     "interval": {
                                         "start": {"type": "Number", "value": 154155307},
                                         "end": {"type": "Number", "value": 154194648},
@@ -371,7 +370,7 @@ def exhaustive_example(alk_gene_descriptor, braf_gene_descriptor):
                                 {
                                     "_id": "ga4gh:VSL.sGJqQhhTg3BYlndAP7nFzN7KoKID1yP_",
                                     "type": "SequenceLocation",
-                                    "sequence_id": "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",  # noqa: E501
+                                    "sequence_id": "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
                                     "interval": {
                                         "start": {"type": "Number", "value": 154155307},
                                         "end": {"type": "Number", "value": 154192100},

--- a/tests/test_fusor.py
+++ b/tests/test_fusor.py
@@ -3,6 +3,8 @@ import copy
 from typing import Dict
 
 import pytest
+from ga4gh.vrsatile.pydantic.vrsatile_models import GeneDescriptor, LocationDescriptor
+
 from fusor.exceptions import FUSORParametersException
 from fusor.models import (
     AssayedFusion,
@@ -17,7 +19,6 @@ from fusor.models import (
     TranscriptSegmentElement,
     UnknownGeneElement,
 )
-from ga4gh.vrsatile.pydantic.vrsatile_models import GeneDescriptor, LocationDescriptor
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_fusor.py
+++ b/tests/test_fusor.py
@@ -3,8 +3,6 @@ import copy
 from typing import Dict
 
 import pytest
-from ga4gh.vrsatile.pydantic.vrsatile_models import GeneDescriptor, LocationDescriptor
-
 from fusor.exceptions import FUSORParametersException
 from fusor.models import (
     AssayedFusion,
@@ -19,6 +17,7 @@ from fusor.models import (
     TranscriptSegmentElement,
     UnknownGeneElement,
 )
+from ga4gh.vrsatile.pydantic.vrsatile_models import GeneDescriptor, LocationDescriptor
 
 
 @pytest.fixture(scope="module")
@@ -383,14 +382,36 @@ def test_add_additional_fields(fusor_instance, fusion_example, fusion_ensg_seque
     fusion = CategoricalFusion(**fusion_example)
 
     expected_fusion = copy.deepcopy(fusion)
-    expected_fusion.critical_functional_domains[0].sequence_location.location_id = "ga4gh:VSL.2CWYzSpOJfZq7KW4VIUKeP5SJtepRar0"  # type: ignore # noqa: E501
-    expected_fusion.critical_functional_domains[0].sequence_location.location.sequence_id = "ga4gh:SQ.q9CnK-HKWh9eqhOi8FlzR7M0pCmUrWPs"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[0].element_genomic_start.location_id = "ga4gh:VSL.H0IOyJ-DB4jTbbSBjQFvuPvMrZHAWSrW"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[0].element_genomic_start.location.sequence_id = "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[0].element_genomic_end.location_id = "ga4gh:VSL.aarSLdMOQ8LoooPB2EoSth41yG_qRmDq"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[0].element_genomic_end.location.sequence_id = "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[3].region.location_id = "ga4gh:VSL.zd12pX_ju2gLq9a9UOYgM8AtbkuhnyUu"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[3].region.location.sequence_id = "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"  # type: ignore # noqa: E501
+    expected_fusion.critical_functional_domains[
+        0
+    ].sequence_location.location_id = "ga4gh:VSL.2CWYzSpOJfZq7KW4VIUKeP5SJtepRar0"
+    expected_fusion.critical_functional_domains[
+        0
+    ].sequence_location.location.sequence_id = (
+        "ga4gh:SQ.q9CnK-HKWh9eqhOi8FlzR7M0pCmUrWPs"
+    )
+    expected_fusion.structural_elements[
+        0
+    ].element_genomic_start.location_id = "ga4gh:VSL.H0IOyJ-DB4jTbbSBjQFvuPvMrZHAWSrW"
+    expected_fusion.structural_elements[
+        0
+    ].element_genomic_start.location.sequence_id = (
+        "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"
+    )
+    expected_fusion.structural_elements[
+        0
+    ].element_genomic_end.location_id = "ga4gh:VSL.aarSLdMOQ8LoooPB2EoSth41yG_qRmDq"
+    expected_fusion.structural_elements[
+        0
+    ].element_genomic_end.location.sequence_id = (
+        "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"
+    )
+    expected_fusion.structural_elements[
+        3
+    ].region.location_id = "ga4gh:VSL.zd12pX_ju2gLq9a9UOYgM8AtbkuhnyUu"
+    expected_fusion.structural_elements[
+        3
+    ].region.location.sequence_id = "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"
 
     actual_fusion = fusor_instance.add_additional_fields(fusion)
     assert actual_fusion.model_dump() == expected_fusion.model_dump()
@@ -408,10 +429,24 @@ def test_add_translated_sequence_id(fusor_instance, fusion_example):
     fusion = CategoricalFusion(**fusion_example)
 
     expected_fusion = copy.deepcopy(fusion)
-    expected_fusion.critical_functional_domains[0].sequence_location.location.sequence_id = "ga4gh:SQ.q9CnK-HKWh9eqhOi8FlzR7M0pCmUrWPs"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[0].element_genomic_start.location.sequence_id = "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[0].element_genomic_end.location.sequence_id = "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"  # type: ignore # noqa: E501
-    expected_fusion.structural_elements[3].region.location.sequence_id = "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"  # type: ignore # noqa: E501
+    expected_fusion.critical_functional_domains[
+        0
+    ].sequence_location.location.sequence_id = (
+        "ga4gh:SQ.q9CnK-HKWh9eqhOi8FlzR7M0pCmUrWPs"
+    )
+    expected_fusion.structural_elements[
+        0
+    ].element_genomic_start.location.sequence_id = (
+        "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"
+    )
+    expected_fusion.structural_elements[
+        0
+    ].element_genomic_end.location.sequence_id = (
+        "ga4gh:SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO"
+    )
+    expected_fusion.structural_elements[
+        3
+    ].region.location.sequence_id = "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP"
 
     actual_fusion = fusor_instance.add_translated_sequence_id(fusion)
     assert actual_fusion.model_dump() == expected_fusion.model_dump()
@@ -508,7 +543,7 @@ def test_fusion(
             "causative_event": {
                 "type": "CausativeEvent",
                 "event_type": "rearrangement",
-                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",  # noqa: E501
+                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
             },
             "assay": {
                 "type": "Assay",
@@ -597,7 +632,7 @@ def test_fusion(
         f = fusor_instance.fusion(
             fusion_type="CategoricalFusion", structural_elements=[linker_element]
         )
-    msg = "Fusions must contain >= 2 structural elements, or >=1 structural element and a regulatory element"  # noqa: E501
+    msg = "Fusions must contain >= 2 structural elements, or >=1 structural element and a regulatory element"
     assert msg in str(excinfo.value)
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,8 +2,6 @@
 import copy
 
 import pytest
-from pydantic import ValidationError
-
 from fusor.models import (
     AbstractFusion,
     Assay,
@@ -20,6 +18,7 @@ from fusor.models import (
     TranscriptSegmentElement,
     UnknownGeneElement,
 )
+from pydantic import ValidationError
 
 
 @pytest.fixture(scope="module")
@@ -456,7 +455,7 @@ def test_transcript_segment_element(transcript_segments):
                 },
             }
         )
-    msg = "Input should be <FUSORTypes.TRANSCRIPT_SEGMENT_ELEMENT: 'TranscriptSegmentElement'>"  # noqa: E501
+    msg = "Input should be <FUSORTypes.TRANSCRIPT_SEGMENT_ELEMENT: 'TranscriptSegmentElement'>"
     check_validation_error(exc_info, msg)
 
     # test element required
@@ -543,7 +542,9 @@ def test_linker_element(linkers):
                 "linker_sequence": {"id": "sequence:ATG", "sequence": "ATG"},
             }
         )
-    msg = "Input should be <FUSORTypes.LINKER_SEQUENCE_ELEMENT: 'LinkerSequenceElement'>"  # noqa: E501
+    msg = (
+        "Input should be <FUSORTypes.LINKER_SEQUENCE_ELEMENT: 'LinkerSequenceElement'>"
+    )
     check_validation_error(exc_info, msg)
 
     # test no extras
@@ -604,7 +605,7 @@ def test_genomic_region_element(templated_sequence_elements, location_descriptor
         assert TemplatedSequenceElement(
             **{"type": "GeneElement", "region": location_descriptors[0], "strand": "+"}
         )
-    msg = "Input should be <FUSORTypes.TEMPLATED_SEQUENCE_ELEMENT: 'TemplatedSequenceElement'>"  # noqa: E501
+    msg = "Input should be <FUSORTypes.TEMPLATED_SEQUENCE_ELEMENT: 'TemplatedSequenceElement'>"
     check_validation_error(exc_info, msg)
 
 
@@ -647,7 +648,7 @@ def test_unknown_gene_element():
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert UnknownGeneElement(type="gene")
-    msg = "Input should be <FUSORTypes.UNKNOWN_GENE_ELEMENT: 'UnknownGeneElement'>"  # noqa: E501
+    msg = "Input should be <FUSORTypes.UNKNOWN_GENE_ELEMENT: 'UnknownGeneElement'>"
     check_validation_error(exc_info, msg)
 
 
@@ -659,7 +660,7 @@ def test_mult_gene_element():
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert MultiplePossibleGenesElement(type="unknown_gene")
-    msg = "Input should be <FUSORTypes.MULTIPLE_POSSIBLE_GENES_ELEMENT: 'MultiplePossibleGenesElement'>"  # noqa: E501
+    msg = "Input should be <FUSORTypes.MULTIPLE_POSSIBLE_GENES_ELEMENT: 'MultiplePossibleGenesElement'>"
     check_validation_error(exc_info, msg)
 
 
@@ -776,7 +777,7 @@ def test_fusion(
             "causative_event": {
                 "type": "CausativeEvent",
                 "event_type": "rearrangement",
-                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",  # noqa: E501
+                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
             },
             "assay": {
                 "type": "Assay",
@@ -849,7 +850,7 @@ def test_fusion_element_count(
                 "causative_event": {
                     "type": "CausativeEvent",
                     "event_type": "rearrangement",
-                    "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",  # noqa: E501
+                    "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
                 },
                 "assay": {
                     "type": "Assay",
@@ -863,7 +864,7 @@ def test_fusion_element_count(
     check_validation_error(exc_info, element_ct_msg)
 
     # unique gene requirements
-    uq_gene_error_msg = "Value error, Fusions must form a chimeric transcript from two or more genes, or a novel interaction between a rearranged regulatory element with the expressed product of a partner gene."  # noqa: E501
+    uq_gene_error_msg = "Value error, Fusions must form a chimeric transcript from two or more genes, or a novel interaction between a rearranged regulatory element with the expressed product of a partner gene."
     with pytest.raises(ValidationError) as exc_info:
         assert CategoricalFusion(
             **{"structural_elements": [gene_elements[0], gene_elements[0]]}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@
 import copy
 
 import pytest
+from pydantic import ValidationError
+
 from fusor.models import (
     AbstractFusion,
     Assay,
@@ -18,7 +20,6 @@ from fusor.models import (
     TranscriptSegmentElement,
     UnknownGeneElement,
 )
-from pydantic import ValidationError
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -337,12 +337,10 @@ def test_functional_domain(functional_domains, gene_descriptors):
     # test status string
     with pytest.raises(ValidationError) as exc_info:
         FunctionalDomain(
-            **{
-                "status": "gained",
-                "name": "tyrosine kinase catalytic domain",
-                "id": "interpro:IPR020635",
-                "associated_gene": gene_descriptors[0],
-            }
+            status="gained",
+            name="tyrosine kinase catalytic domain",
+            id="interpro:IPR020635",
+            associated_gene=gene_descriptors[0],
         )
     msg = "Input should be 'lost' or 'preserved'"
     check_validation_error(exc_info, msg)
@@ -350,14 +348,12 @@ def test_functional_domain(functional_domains, gene_descriptors):
     # test domain ID CURIE requirement
     with pytest.raises(ValidationError) as exc_info:
         FunctionalDomain(
-            **{
-                "status": "lost",
-                "label": "tyrosine kinase catalytic domain",
-                "id": "interpro_IPR020635",
-                "associated_gene": gene_descriptors[0],
-            }
+            status="lost",
+            label="tyrosine kinase catalytic domain",
+            id="interpro_IPR020635",
+            associated_gene=gene_descriptors[0],
         )
-    msg = "String should match pattern '^\\w[^:]*:.+$'"  # noqa: W605, Q003
+    msg = "String should match pattern '^\\w[^:]*:.+$'"
     check_validation_error(exc_info, msg)
 
 
@@ -395,66 +391,62 @@ def test_transcript_segment_element(transcript_segments):
     # check CURIE requirement
     with pytest.raises(ValidationError) as exc_info:
         TranscriptSegmentElement(
-            **{
-                "transcript": "NM_152263.3",
-                "exon_start": "1",
-                "exon_start_offset": "-9",
-                "exon_end": "8",
-                "exon_end_offset": "7",
-                "gene_descriptor": {
-                    "id": "test:1",
-                    "gene": {"id": "hgnc:1"},
-                    "label": "G1",
-                },
-                "element_genomic_start": {
-                    "location": {
-                        "species_id": "taxonomy:9606",
-                        "chr": "12",
-                        "interval": {"start": "p12.1", "end": "p12.1"},
-                    }
-                },
-                "element_genomic_end": {
-                    "location": {
-                        "species_id": "taxonomy:9606",
-                        "chr": "12",
-                        "interval": {"start": "p12.2", "end": "p12.2"},
-                    }
-                },
-            }
+            transcript="NM_152263.3",
+            exon_start="1",
+            exon_start_offset="-9",
+            exon_end="8",
+            exon_end_offset="7",
+            gene_descriptor={
+                "id": "test:1",
+                "gene": {"id": "hgnc:1"},
+                "label": "G1",
+            },
+            element_genomic_start={
+                "location": {
+                    "species_id": "taxonomy:9606",
+                    "chr": "12",
+                    "interval": {"start": "p12.1", "end": "p12.1"},
+                }
+            },
+            element_genomic_end={
+                "location": {
+                    "species_id": "taxonomy:9606",
+                    "chr": "12",
+                    "interval": {"start": "p12.2", "end": "p12.2"},
+                }
+            },
         )
-    msg = "String should match pattern '^\\w[^:]*:.+$'"  # noqa: W605, Q003
+    msg = "String should match pattern '^\\w[^:]*:.+$'"
     check_validation_error(exc_info, msg)
 
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert TranscriptSegmentElement(
-            **{
-                "type": "TemplatedSequenceElement",
-                "transcript": "NM_152263.3",
-                "exon_start": "1",
-                "exon_start_offset": "-9",
-                "exon_end": "8",
-                "exon_end_offset": "7",
-                "gene_descriptor": {
-                    "id": "test:1",
-                    "gene": {"id": "hgnc:1"},
-                    "label": "G1",
-                },
-                "element_genomic_start": {
-                    "location": {
-                        "species_id": "taxonomy:9606",
-                        "chr": "12",
-                        "interval": {"start": "p12.1", "end": "p12.2"},
-                    }
-                },
-                "element_genomic_end": {
-                    "location": {
-                        "species_id": "taxonomy:9606",
-                        "chr": "12",
-                        "interval": {"start": "p12.2", "end": "p12.2"},
-                    }
-                },
-            }
+            type="TemplatedSequenceElement",
+            transcript="NM_152263.3",
+            exon_start="1",
+            exon_start_offset="-9",
+            exon_end="8",
+            exon_end_offset="7",
+            gene_descriptor={
+                "id": "test:1",
+                "gene": {"id": "hgnc:1"},
+                "label": "G1",
+            },
+            element_genomic_start={
+                "location": {
+                    "species_id": "taxonomy:9606",
+                    "chr": "12",
+                    "interval": {"start": "p12.1", "end": "p12.2"},
+                }
+            },
+            element_genomic_end={
+                "location": {
+                    "species_id": "taxonomy:9606",
+                    "chr": "12",
+                    "interval": {"start": "p12.2", "end": "p12.2"},
+                }
+            },
         )
     msg = "Input should be <FUSORTypes.TRANSCRIPT_SEGMENT_ELEMENT: 'TranscriptSegmentElement'>"
     check_validation_error(exc_info, msg)
@@ -462,51 +454,47 @@ def test_transcript_segment_element(transcript_segments):
     # test element required
     with pytest.raises(ValidationError) as exc_info:
         assert TranscriptSegmentElement(
-            **{
-                "element_type": "templated_sequence",
-                "transcript": "NM_152263.3",
-                "exon_start": "1",
-                "exon_start_offset": "-9",
-                "gene_descriptor": {
-                    "id": "test:1",
-                    "gene": {"id": "hgnc:1"},
-                    "label": "G1",
-                },
-            }
+            element_type="templated_sequence",
+            transcript="NM_152263.3",
+            exon_start="1",
+            exon_start_offset="-9",
+            gene_descriptor={
+                "id": "test:1",
+                "gene": {"id": "hgnc:1"},
+                "label": "G1",
+            },
         )
-    msg = "Assertion failed, Must give `element_genomic_start` if `exon_start` is given"
+    msg = "Value error, Must give `element_genomic_start` if `exon_start` is given"
     check_validation_error(exc_info, msg)
 
     # Neither exon_start or exon_end given
     with pytest.raises(ValidationError) as exc_info:
         assert TranscriptSegmentElement(
-            **{
-                "type": "TranscriptSegmentElement",
-                "transcript": "NM_152263.3",
-                "exon_start_offset": "-9",
-                "exon_end_offset": "7",
-                "gene_descriptor": {
-                    "id": "test:1",
-                    "gene": {"id": "hgnc:1"},
-                    "label": "G1",
-                },
-                "element_genomic_start": {
-                    "location": {
-                        "species_id": "taxonomy:9606",
-                        "chr": "12",
-                        "interval": {"start": "p12.1", "end": "p12.2"},
-                    }
-                },
-                "element_genomic_end": {
-                    "location": {
-                        "species_id": "taxonomy:9606",
-                        "chr": "12",
-                        "interval": {"start": "p12.2", "end": "p12.2"},
-                    }
-                },
-            }
+            type="TranscriptSegmentElement",
+            transcript="NM_152263.3",
+            exon_start_offset="-9",
+            exon_end_offset="7",
+            gene_descriptor={
+                "id": "test:1",
+                "gene": {"id": "hgnc:1"},
+                "label": "G1",
+            },
+            element_genomic_start={
+                "location": {
+                    "species_id": "taxonomy:9606",
+                    "chr": "12",
+                    "interval": {"start": "p12.1", "end": "p12.2"},
+                }
+            },
+            element_genomic_end={
+                "location": {
+                    "species_id": "taxonomy:9606",
+                    "chr": "12",
+                    "interval": {"start": "p12.2", "end": "p12.2"},
+                }
+            },
         )
-    msg = "Assertion failed, Must give values for either `exon_start`, `exon_end`, or both"
+    msg = "Value error, Must give values for either `exon_start`, `exon_end`, or both"
     check_validation_error(exc_info, msg)
 
 
@@ -529,19 +517,15 @@ def test_linker_element(linkers):
 
     # check base validation
     with pytest.raises(ValidationError) as exc_info:
-        LinkerElement(
-            **{"linker_sequence": {"id": "sequence:ACT1", "sequence": "ACT1"}}
-        )
+        LinkerElement(linker_sequence={"id": "sequence:ACT1", "sequence": "ACT1"})
     msg = "String should match pattern '^[A-Z*\\-]*$'"
     check_validation_error(exc_info, msg)
 
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert LinkerElement(
-            **{
-                "type": "TemplatedSequenceElement",
-                "linker_sequence": {"id": "sequence:ATG", "sequence": "ATG"},
-            }
+            type="TemplatedSequenceElement",
+            linker_sequence={"id": "sequence:ATG", "sequence": "ATG"},
         )
     msg = (
         "Input should be <FUSORTypes.LINKER_SEQUENCE_ELEMENT: 'LinkerSequenceElement'>"
@@ -551,11 +535,9 @@ def test_linker_element(linkers):
     # test no extras
     with pytest.raises(ValidationError) as exc_info:
         assert LinkerElement(
-            **{
-                "type": "LinkerSequenceElement",
-                "linker_sequence": {"id": "sequence:G", "sequence": "G"},
-                "bonus_value": "bonus",
-            }
+            type="LinkerSequenceElement",
+            linker_sequence={"id": "sequence:G", "sequence": "G"},
+            bonus_value="bonus",
         )
     msg = "Extra inputs are not permitted"
     check_validation_error(exc_info, msg)
@@ -593,10 +575,8 @@ def test_genomic_region_element(templated_sequence_elements, location_descriptor
 
     with pytest.raises(ValidationError) as exc_info:
         TemplatedSequenceElement(
-            **{
-                "region": {"interval": {"start": 39408, "stop": 39414}},
-                "sequence_id": "ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl",
-            }
+            region={"interval": {"start": 39408, "stop": 39414}},
+            sequence_id="ga4gh:SQ.6wlJpONE3oNb4D69ULmEXhqyDZ4vwNfl",
         )
     msg = "Field required"
     check_validation_error(exc_info, msg)
@@ -604,7 +584,7 @@ def test_genomic_region_element(templated_sequence_elements, location_descriptor
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert TemplatedSequenceElement(
-            **{"type": "GeneElement", "region": location_descriptors[0], "strand": "+"}
+            type="GeneElement", region=location_descriptors[0], strand="+"
         )
     msg = "Input should be <FUSORTypes.TEMPLATED_SEQUENCE_ELEMENT: 'TemplatedSequenceElement'>"
     check_validation_error(exc_info, msg)
@@ -612,7 +592,7 @@ def test_genomic_region_element(templated_sequence_elements, location_descriptor
 
 def test_gene_element(gene_descriptors):
     """Test that Gene Element initializes correctly."""
-    test_element = GeneElement(**{"gene_descriptor": gene_descriptors[0]})
+    test_element = GeneElement(gene_descriptor=gene_descriptors[0])
     assert test_element.type == "GeneElement"
     assert test_element.gene_descriptor.id == "gene:G1"
     assert test_element.gene_descriptor.label == "G1"
@@ -621,21 +601,19 @@ def test_gene_element(gene_descriptors):
     # test CURIE requirement
     with pytest.raises(ValidationError) as exc_info:
         GeneElement(
-            **{
-                "gene_descriptor": {
-                    "id": "G1",
-                    "gene": {"gene_id": "hgnc:9339"},
-                    "label": "G1",
-                }
+            gene_descriptor={
+                "id": "G1",
+                "gene": {"gene_id": "hgnc:9339"},
+                "label": "G1",
             }
         )
-    msg = "String should match pattern '^\\w[^:]*:.+$'"  # noqa: W605, Q003
+    msg = "String should match pattern '^\\w[^:]*:.+$'"
     check_validation_error(exc_info, msg)
 
     # test enum validation
     with pytest.raises(ValidationError) as exc_info:
         assert GeneElement(
-            **{"type": "UnknownGeneElement", "gene_descriptor": gene_descriptors[0]}
+            type="UnknownGeneElement", gene_descriptor=gene_descriptors[0]
         )
     msg = "Input should be <FUSORTypes.GENE_ELEMENT: 'GeneElement'>"
     check_validation_error(exc_info, msg)
@@ -671,7 +649,7 @@ def test_event():
     test_event = CausativeEvent(event_type=rearrangement, event_description=None)
     assert test_event.event_type == rearrangement
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError):  # noqa: PT011
         CausativeEvent(event_type="combination")
 
 
@@ -686,20 +664,13 @@ def test_regulatory_element(regulatory_elements, gene_descriptors):
     # check type constraint
     with pytest.raises(ValidationError) as exc_info:
         RegulatoryElement(
-            **{
-                "regulatory_class": "notpromoter",
-                "associated_gene": gene_descriptors[0],
-            }
+            regulatory_class="notpromoter", associated_gene=gene_descriptors[0]
         )
     assert exc_info.value.errors()[0]["msg"].startswith("Input should be")
 
     # require minimum input
     with pytest.raises(ValidationError) as exc_info:
-        RegulatoryElement(
-            **{
-                "regulatory_class": "enhancer",
-            }
-        )
+        RegulatoryElement(regulatory_class="enhancer")
     assert (
         exc_info.value.errors()[0]["msg"]
         == "Value error, Must set 1 of {`feature_id`, `associated_gene`} and/or `feature_location`"
@@ -718,41 +689,37 @@ def test_fusion(
     """Test that Fusion object initializes correctly"""
     # test valid object
     fusion = CategoricalFusion(
-        **{
-            "r_frame_preserved": True,
-            "critical_functional_domains": [functional_domains[0]],
-            "structural_elements": [transcript_segments[1], transcript_segments[2]],
-            "regulatory_element": regulatory_elements[0],
-        }
+        r_frame_preserved=True,
+        critical_functional_domains=[functional_domains[0]],
+        structural_elements=[transcript_segments[1], transcript_segments[2]],
+        regulatory_element=regulatory_elements[0],
     )
 
     assert fusion.structural_elements[0].transcript == "refseq:NM_034348.3"
 
     # check correct parsing of nested items
     fusion = CategoricalFusion(
-        **{
-            "structural_elements": [
-                {
-                    "type": "GeneElement",
-                    "gene_descriptor": {
-                        "type": "GeneDescriptor",
-                        "id": "gene:NTRK1",
-                        "label": "NTRK1",
-                        "gene_id": "hgnc:8031",
-                    },
+        structural_elements=[
+            {
+                "type": "GeneElement",
+                "gene_descriptor": {
+                    "type": "GeneDescriptor",
+                    "id": "gene:NTRK1",
+                    "label": "NTRK1",
+                    "gene_id": "hgnc:8031",
                 },
-                {
-                    "type": "GeneElement",
-                    "gene_descriptor": {
-                        "type": "GeneDescriptor",
-                        "id": "gene:ABL1",
-                        "label": "ABL1",
-                        "gene_id": "hgnc:76",
-                    },
+            },
+            {
+                "type": "GeneElement",
+                "gene_descriptor": {
+                    "type": "GeneDescriptor",
+                    "id": "gene:ABL1",
+                    "label": "ABL1",
+                    "gene_id": "hgnc:76",
                 },
-            ],
-            "regulatory_element": None,
-        }
+            },
+        ],
+        regulatory_element=None,
     )
     assert fusion.structural_elements[0].type == "GeneElement"
     assert fusion.structural_elements[0].gene_descriptor.id == "gene:NTRK1"
@@ -761,59 +728,55 @@ def test_fusion(
 
     # test that non-element properties are optional
     assert CategoricalFusion(
-        **{"structural_elements": [transcript_segments[1], transcript_segments[2]]}
+        structural_elements=[transcript_segments[1], transcript_segments[2]]
     )
 
     # test variety of element types
     assert AssayedFusion(
-        **{
-            "type": "AssayedFusion",
-            "structural_elements": [
-                unknown_element,
-                gene_elements[0],
-                transcript_segments[2],
-                templated_sequence_elements[1],
-                linkers[0],
-            ],
-            "causative_event": {
-                "type": "CausativeEvent",
-                "event_type": "rearrangement",
-                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
-            },
-            "assay": {
-                "type": "Assay",
-                "method_uri": "pmid:33576979",
-                "assay_id": "obi:OBI_0003094",
-                "assay_name": "fluorescence in-situ hybridization assay",
-                "fusion_detection": "inferred",
-            },
-        }
+        type="AssayedFusion",
+        structural_elements=[
+            unknown_element,
+            gene_elements[0],
+            transcript_segments[2],
+            templated_sequence_elements[1],
+            linkers[0],
+        ],
+        causative_event={
+            "type": "CausativeEvent",
+            "event_type": "rearrangement",
+            "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
+        },
+        assay={
+            "type": "Assay",
+            "method_uri": "pmid:33576979",
+            "assay_id": "obi:OBI_0003094",
+            "assay_name": "fluorescence in-situ hybridization assay",
+            "fusion_detection": "inferred",
+        },
     )
     with pytest.raises(ValidationError) as exc_info:
         assert CategoricalFusion(
-            **{
-                "type": "CategoricalFusion",
-                "structural_elements": [
-                    {
-                        "type": "LinkerSequenceElement",
-                        "linker_sequence": {
-                            "id": "a:b",
-                            "type": "SequenceDescriptor",
-                            "sequence": "AC",
-                            "residue_type": "SO:0000348",
-                        },
+            type="CategoricalFusion",
+            structural_elements=[
+                {
+                    "type": "LinkerSequenceElement",
+                    "linker_sequence": {
+                        "id": "a:b",
+                        "type": "SequenceDescriptor",
+                        "sequence": "AC",
+                        "residue_type": "SO:0000348",
                     },
-                    {
-                        "type": "LinkerSequenceElement",
-                        "linker_sequence": {
-                            "id": "a:b",
-                            "type": "SequenceDescriptor",
-                            "sequence": "AC",
-                            "residue_type": "SO:0000348",
-                        },
+                },
+                {
+                    "type": "LinkerSequenceElement",
+                    "linker_sequence": {
+                        "id": "a:b",
+                        "type": "SequenceDescriptor",
+                        "sequence": "AC",
+                        "residue_type": "SO:0000348",
                     },
-                ],
-            }
+                },
+            ],
         )
     msg = "Value error, First structural element cannot be LinkerSequence"
     check_validation_error(exc_info, msg)
@@ -831,11 +794,9 @@ def test_fusion_element_count(
     # elements are mandatory
     with pytest.raises(ValidationError) as exc_info:
         assert AssayedFusion(
-            **{
-                "functional_domains": [functional_domains[1]],
-                "causative_event": "rearrangement",
-                "regulatory_elements": [regulatory_elements[0]],
-            }
+            functional_domains=[functional_domains[1]],
+            causative_event="rearrangement",
+            regulatory_elements=[regulatory_elements[0]],
         )
     element_ct_msg = (
         "Value error, Fusions must contain >= 2 structural elements, or >=1 structural element "
@@ -846,21 +807,19 @@ def test_fusion_element_count(
     # must have >= 2 elements + regulatory elements
     with pytest.raises(ValidationError) as exc_info:
         assert AssayedFusion(
-            **{
-                "structural_elements": [unknown_element],
-                "causative_event": {
-                    "type": "CausativeEvent",
-                    "event_type": "rearrangement",
-                    "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
-                },
-                "assay": {
-                    "type": "Assay",
-                    "method_uri": "pmid:33576979",
-                    "assay_id": "obi:OBI_0003094",
-                    "assay_name": "fluorescence in-situ hybridization assay",
-                    "fusion_detection": "inferred",
-                },
-            }
+            structural_elements=[unknown_element],
+            causative_event={
+                "type": "CausativeEvent",
+                "event_type": "rearrangement",
+                "event_description": "chr2:g.pter_8,247,756::chr11:g.15,825,273_cen_qter (der11) and chr11:g.pter_15,825,272::chr2:g.8,247,757_cen_qter (der2)",
+            },
+            assay={
+                "type": "Assay",
+                "method_uri": "pmid:33576979",
+                "assay_id": "obi:OBI_0003094",
+                "assay_name": "fluorescence in-situ hybridization assay",
+                "fusion_detection": "inferred",
+            },
         )
     check_validation_error(exc_info, element_ct_msg)
 
@@ -868,72 +827,66 @@ def test_fusion_element_count(
     uq_gene_error_msg = "Value error, Fusions must form a chimeric transcript from two or more genes, or a novel interaction between a rearranged regulatory element with the expressed product of a partner gene."
     with pytest.raises(ValidationError) as exc_info:
         assert CategoricalFusion(
-            **{"structural_elements": [gene_elements[0], gene_elements[0]]}
+            structural_elements=[gene_elements[0], gene_elements[0]]
         )
     check_validation_error(exc_info, uq_gene_error_msg)
 
     with pytest.raises(ValidationError) as exc_info:
         assert CategoricalFusion(
-            **{"structural_elements": [gene_elements[1], transcript_segments[0]]}
+            structural_elements=[gene_elements[1], transcript_segments[0]]
         )
     check_validation_error(exc_info, uq_gene_error_msg)
 
     with pytest.raises(ValidationError) as exc_info:
         assert CategoricalFusion(
-            **{
-                "regulatory_element": regulatory_elements[0],
-                "structural_elements": [transcript_segments[0]],
-            }
+            regulatory_element=regulatory_elements[0],
+            structural_elements=[transcript_segments[0]],
         )
     check_validation_error(exc_info, uq_gene_error_msg)
 
     # use alternate gene descriptor structure
     with pytest.raises(ValidationError) as exc_info:
         assert AssayedFusion(
-            **{
-                "type": "AssayedFusion",
-                "structural_elements": [
-                    {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
-                    {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
-                ],
-                "causative_event": {
-                    "type": "CausativeEvent",
-                    "event_type": "read-through",
-                },
-                "assay": {
-                    "type": "Assay",
-                    "method_uri": "pmid:33576979",
-                    "assay_id": "obi:OBI_0003094",
-                    "assay_name": "fluorescence in-situ hybridization assay",
-                    "fusion_detection": "inferred",
-                },
-            }
+            type="AssayedFusion",
+            structural_elements=[
+                {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
+                {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
+            ],
+            causative_event={
+                "type": "CausativeEvent",
+                "event_type": "read-through",
+            },
+            assay={
+                "type": "Assay",
+                "method_uri": "pmid:33576979",
+                "assay_id": "obi:OBI_0003094",
+                "assay_name": "fluorescence in-situ hybridization assay",
+                "fusion_detection": "inferred",
+            },
         )
     with pytest.raises(ValidationError) as exc_info:
         assert AssayedFusion(
-            **{
-                "type": "AssayedFusion",
-                "structural_elements": [
-                    {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
-                ],
-                "regulatory_element": {
-                    "type": "RegulatoryElement",
-                    "regulatory_class": "enhancer",
-                    "feature_id": "EH111111111",
-                    "associated_gene": gene_descriptors[6],
-                },
-                "causative_event": {
-                    "type": "CausativeEvent",
-                    "event_type": "read-through",
-                },
-                "assay": {
-                    "type": "Assay",
-                    "method_uri": "pmid:33576979",
-                    "assay_id": "obi:OBI_0003094",
-                    "assay_name": "fluorescence in-situ hybridization assay",
-                    "fusion_detection": "inferred",
-                },
-            }
+            type="AssayedFusion",
+            structural_elements=[
+                {"type": "GeneElement", "gene_descriptor": gene_descriptors[6]},
+            ],
+            regulatory_element={
+                "type": "RegulatoryElement",
+                "regulatory_class": "enhancer",
+                "feature_id": "EH111111111",
+                "associated_gene": gene_descriptors[6],
+            },
+            causative_event={
+                "type": "CausativeEvent",
+                "event_type": "read-through",
+            },
+            assay={
+                "type": "Assay",
+                "method_uri": "pmid:33576979",
+                "assay_id": "obi:OBI_0003094",
+                "assay_name": "fluorescence in-situ hybridization assay",
+                "fusion_detection": "inferred",
+            },
         )
 
 
@@ -941,9 +894,7 @@ def test_fusion_abstraction_validator(transcript_segments, linkers):
     """Test that instantiation of abstract fusion fails."""
     # can't create base fusion
     with pytest.raises(ValidationError) as exc_info:
-        assert AbstractFusion(
-            **{"structural_elements": [transcript_segments[2], linkers[0]]}
-        )
+        assert AbstractFusion(structural_elements=[transcript_segments[2], linkers[0]])
     check_validation_error(
         exc_info, "Value error, Cannot instantiate Fusion abstract class"
     )
@@ -952,7 +903,7 @@ def test_fusion_abstraction_validator(transcript_segments, linkers):
 def test_file_examples():
     """Test example JSON files."""
     # if this loads, then Pydantic validation was successful
-    import fusor.examples as _  # noqa: F401 I001
+    import fusor.examples as _  # noqa: F401
 
 
 def test_model_examples():

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -1,6 +1,5 @@
 """Test nomenclature generation."""
 import pytest
-
 from fusor.models import AssayedFusion, CategoricalFusion, TranscriptSegmentElement
 from fusor.nomenclature import tx_segment_nomenclature
 
@@ -285,7 +284,7 @@ def test_generate_nomenclature(
     nm = fusor_instance.generate_nomenclature(reg_location_example)
     assert (
         nm
-        == "reg_p_NC_000023.11(chr X):g.1462581_1534182@P2RY8(hgnc:15524)::SOX5(hgnc:11201)"  # noqa: E501
+        == "reg_p_NC_000023.11(chr X):g.1462581_1534182@P2RY8(hgnc:15524)::SOX5(hgnc:11201)"
     )
 
     nm = fusor_instance.generate_nomenclature(exon_offset_example)

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -1,5 +1,6 @@
 """Test nomenclature generation."""
 import pytest
+
 from fusor.models import AssayedFusion, CategoricalFusion, TranscriptSegmentElement
 from fusor.nomenclature import tx_segment_nomenclature
 

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -9,42 +9,40 @@ from fusor.nomenclature import tx_segment_nomenclature
 def reg_example():
     """Nonsense fusion testing correct regulatory element description."""
     return AssayedFusion(
-        **{
-            "type": "AssayedFusion",
-            "regulatory_element": {
-                "type": "RegulatoryElement",
-                "regulatory_class": "riboswitch",
-                "associated_gene": {
-                    "id": "normalize.gene:ABL1",
+        type="AssayedFusion",
+        regulatory_element={
+            "type": "RegulatoryElement",
+            "regulatory_class": "riboswitch",
+            "associated_gene": {
+                "id": "normalize.gene:ABL1",
+                "type": "GeneDescriptor",
+                "label": "ABL1",
+                "gene_id": "hgnc:76",
+            },
+        },
+        structural_elements=[
+            {
+                "type": "GeneElement",
+                "gene_descriptor": {
+                    "id": "normalize.gene:BCR",
                     "type": "GeneDescriptor",
-                    "label": "ABL1",
-                    "gene_id": "hgnc:76",
+                    "label": "BCR",
+                    "gene_id": "hgnc:1014",
                 },
             },
-            "structural_elements": [
-                {
-                    "type": "GeneElement",
-                    "gene_descriptor": {
-                        "id": "normalize.gene:BCR",
-                        "type": "GeneDescriptor",
-                        "label": "BCR",
-                        "gene_id": "hgnc:1014",
-                    },
-                },
-                {"type": "UnknownGeneElement"},
-            ],
-            "causative_event": {
-                "type": "CausativeEvent",
-                "event_type": "rearrangement",
-            },
-            "assay": {
-                "type": "Assay",
-                "assay_name": "a",
-                "assay_id": "a:b",
-                "method_uri": "a:b",
-                "fusion_detection": "observed",
-            },
-        }
+            {"type": "UnknownGeneElement"},
+        ],
+        causative_event={
+            "type": "CausativeEvent",
+            "event_type": "rearrangement",
+        },
+        assay={
+            "type": "Assay",
+            "assay_name": "a",
+            "assay_id": "a:b",
+            "method_uri": "a:b",
+            "fusion_detection": "observed",
+        },
     )
 
 
@@ -52,54 +50,52 @@ def reg_example():
 def reg_location_example():
     """Nonsense fusion testing correct regulatory element description."""
     return AssayedFusion(
-        **{
-            "type": "AssayedFusion",
-            "regulatory_element": {
-                "type": "RegulatoryElement",
-                "regulatory_class": "promoter",
-                "associated_gene": {
-                    "id": "normalize.gene:P2RY8",
+        type="AssayedFusion",
+        regulatory_element={
+            "type": "RegulatoryElement",
+            "regulatory_class": "promoter",
+            "associated_gene": {
+                "id": "normalize.gene:P2RY8",
+                "type": "GeneDescriptor",
+                "label": "P2RY8",
+                "gene_id": "hgnc:15524",
+            },
+            "feature_location": {
+                "type": "LocationDescriptor",
+                "id": "fusor.location_descriptor:NC_000023.11",
+                "location": {
+                    "sequence_id": "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
+                    "type": "SequenceLocation",
+                    "interval": {
+                        "type": "SequenceInterval",
+                        "start": {"type": "Number", "value": 1462581},
+                        "end": {"type": "Number", "value": 1534182},
+                    },
+                },
+            },
+        },
+        structural_elements=[
+            {
+                "type": "GeneElement",
+                "gene_descriptor": {
+                    "id": "normalize.gene:SOX5",
                     "type": "GeneDescriptor",
-                    "label": "P2RY8",
-                    "gene_id": "hgnc:15524",
-                },
-                "feature_location": {
-                    "type": "LocationDescriptor",
-                    "id": "fusor.location_descriptor:NC_000023.11",
-                    "location": {
-                        "sequence_id": "ga4gh:SQ.w0WZEvgJF0zf_P4yyTzjjv9oW1z61HHP",
-                        "type": "SequenceLocation",
-                        "interval": {
-                            "type": "SequenceInterval",
-                            "start": {"type": "Number", "value": 1462581},
-                            "end": {"type": "Number", "value": 1534182},
-                        },
-                    },
+                    "label": "SOX5",
+                    "gene_id": "hgnc:11201",
                 },
             },
-            "structural_elements": [
-                {
-                    "type": "GeneElement",
-                    "gene_descriptor": {
-                        "id": "normalize.gene:SOX5",
-                        "type": "GeneDescriptor",
-                        "label": "SOX5",
-                        "gene_id": "hgnc:11201",
-                    },
-                },
-            ],
-            "causative_event": {
-                "type": "CausativeEvent",
-                "event_type": "rearrangement",
-            },
-            "assay": {
-                "type": "Assay",
-                "assay_name": "a",
-                "assay_id": "a:b",
-                "method_uri": "a:b",
-                "fusion_detection": "observed",
-            },
-        }
+        ],
+        causative_event={
+            "type": "CausativeEvent",
+            "event_type": "rearrangement",
+        },
+        assay={
+            "type": "Assay",
+            "assay_name": "a",
+            "assay_id": "a:b",
+            "method_uri": "a:b",
+            "fusion_detection": "observed",
+        },
     )
 
 
@@ -107,46 +103,44 @@ def reg_location_example():
 def exon_offset_example():
     """Provide example of tx segment with positive exon end offset"""
     return CategoricalFusion(
-        **{
-            "type": "CategoricalFusion",
-            "structural_elements": [
-                {
-                    "type": "GeneElement",
-                    "gene_descriptor": {
-                        "id": "normalize.gene:BRAF",
-                        "type": "GeneDescriptor",
-                        "label": "BRAF",
-                        "gene_id": "hgnc:1097",
-                    },
+        type="CategoricalFusion",
+        structural_elements=[
+            {
+                "type": "GeneElement",
+                "gene_descriptor": {
+                    "id": "normalize.gene:BRAF",
+                    "type": "GeneDescriptor",
+                    "label": "BRAF",
+                    "gene_id": "hgnc:1097",
                 },
-                {
-                    "type": "TranscriptSegmentElement",
-                    "transcript": "refseq:NM_002529.3",
-                    "exon_start": 2,
-                    "exon_start_offset": 20,
-                    "gene_descriptor": {
-                        "id": "normalize.gene:NTRK1",
-                        "type": "GeneDescriptor",
-                        "label": "NTRK1",
-                        "gene_id": "hgnc:8031",
-                    },
-                    "element_genomic_start": {
-                        "id": "fusor.location_descriptor:NC_000001.11",
-                        "type": "LocationDescriptor",
-                        "label": "NC_000001.11",
-                        "location": {
-                            "type": "SequenceLocation",
-                            "sequence_id": "refseq:NC_000001.11",
-                            "interval": {
-                                "type": "SequenceInterval",
-                                "start": {"type": "Number", "value": 156864428},
-                                "end": {"type": "Number", "value": 156864429},
-                            },
+            },
+            {
+                "type": "TranscriptSegmentElement",
+                "transcript": "refseq:NM_002529.3",
+                "exon_start": 2,
+                "exon_start_offset": 20,
+                "gene_descriptor": {
+                    "id": "normalize.gene:NTRK1",
+                    "type": "GeneDescriptor",
+                    "label": "NTRK1",
+                    "gene_id": "hgnc:8031",
+                },
+                "element_genomic_start": {
+                    "id": "fusor.location_descriptor:NC_000001.11",
+                    "type": "LocationDescriptor",
+                    "label": "NC_000001.11",
+                    "location": {
+                        "type": "SequenceLocation",
+                        "sequence_id": "refseq:NC_000001.11",
+                        "interval": {
+                            "type": "SequenceInterval",
+                            "start": {"type": "Number", "value": 156864428},
+                            "end": {"type": "Number", "value": 156864429},
                         },
                     },
                 },
-            ],
-        }
+            },
+        ],
     )
 
 
@@ -154,48 +148,46 @@ def exon_offset_example():
 def tx_seg_example():
     """Provide example of transcript segment element."""
     return TranscriptSegmentElement(
-        **{
-            "type": "TranscriptSegmentElement",
-            "transcript": "refseq:NM_152263.3",
-            "exon_start": 1,
-            "exon_start_offset": 0,
-            "exon_end": 8,
-            "exon_end_offset": 0,
-            "gene_descriptor": {
-                "id": "normalize.gene:TPM3",
-                "type": "GeneDescriptor",
-                "label": "TPM3",
-                "gene_id": "hgnc:12012",
-            },
-            "element_genomic_start": {
-                "id": "fusor.location_descriptor:NC_000001.11",
-                "type": "LocationDescriptor",
-                "label": "NC_000001.11",
-                "location": {
-                    "type": "SequenceLocation",
-                    "sequence_id": "refseq:NC_000001.11",
-                    "interval": {
-                        "type": "SequenceInterval",
-                        "start": {"type": "Number", "value": 154192135},
-                        "end": {"type": "Number", "value": 154192136},
-                    },
+        type="TranscriptSegmentElement",
+        transcript="refseq:NM_152263.3",
+        exon_start=1,
+        exon_start_offset=0,
+        exon_end=8,
+        exon_end_offset=0,
+        gene_descriptor={
+            "id": "normalize.gene:TPM3",
+            "type": "GeneDescriptor",
+            "label": "TPM3",
+            "gene_id": "hgnc:12012",
+        },
+        element_genomic_start={
+            "id": "fusor.location_descriptor:NC_000001.11",
+            "type": "LocationDescriptor",
+            "label": "NC_000001.11",
+            "location": {
+                "type": "SequenceLocation",
+                "sequence_id": "refseq:NC_000001.11",
+                "interval": {
+                    "type": "SequenceInterval",
+                    "start": {"type": "Number", "value": 154192135},
+                    "end": {"type": "Number", "value": 154192136},
                 },
             },
-            "element_genomic_end": {
-                "id": "fusor.location_descriptor:NC_000001.11",
-                "type": "LocationDescriptor",
-                "label": "NC_000001.11",
-                "location": {
-                    "type": "SequenceLocation",
-                    "sequence_id": "refseq:NC_000001.11",
-                    "interval": {
-                        "type": "SequenceInterval",
-                        "start": {"type": "Number", "value": 154170399},
-                        "end": {"type": "Number", "value": 154170400},
-                    },
+        },
+        element_genomic_end={
+            "id": "fusor.location_descriptor:NC_000001.11",
+            "type": "LocationDescriptor",
+            "label": "NC_000001.11",
+            "location": {
+                "type": "SequenceLocation",
+                "sequence_id": "refseq:NC_000001.11",
+                "interval": {
+                    "type": "SequenceInterval",
+                    "start": {"type": "Number", "value": 154170399},
+                    "end": {"type": "Number", "value": 154170400},
                 },
             },
-        }
+        },
     )
 
 
@@ -203,32 +195,30 @@ def tx_seg_example():
 def junction_example():
     """Provide example of junction element."""
     return TranscriptSegmentElement(
-        **{
-            "type": "TranscriptSegmentElement",
-            "transcript": "refseq:NM_152263.3",
-            "exon_end": 8,
-            "exon_end_offset": 0,
-            "gene_descriptor": {
-                "id": "normalize.gene:TPM3",
-                "type": "GeneDescriptor",
-                "label": "TPM3",
-                "gene_id": "hgnc:12012",
-            },
-            "element_genomic_end": {
-                "id": "fusor.location_descriptor:NC_000001.11",
-                "type": "LocationDescriptor",
-                "label": "NC_000001.11",
-                "location": {
-                    "type": "SequenceLocation",
-                    "sequence_id": "refseq:NC_000001.11",
-                    "interval": {
-                        "type": "SequenceInterval",
-                        "start": {"type": "Number", "value": 154170399},
-                        "end": {"type": "Number", "value": 154170400},
-                    },
+        type="TranscriptSegmentElement",
+        transcript="refseq:NM_152263.3",
+        exon_end=8,
+        exon_end_offset=0,
+        gene_descriptor={
+            "id": "normalize.gene:TPM3",
+            "type": "GeneDescriptor",
+            "label": "TPM3",
+            "gene_id": "hgnc:12012",
+        },
+        element_genomic_end={
+            "id": "fusor.location_descriptor:NC_000001.11",
+            "type": "LocationDescriptor",
+            "label": "NC_000001.11",
+            "location": {
+                "type": "SequenceLocation",
+                "sequence_id": "refseq:NC_000001.11",
+                "interval": {
+                    "type": "SequenceInterval",
+                    "start": {"type": "Number", "value": 154170399},
+                    "end": {"type": "Number", "value": 154170400},
                 },
             },
-        }
+        },
     )
 
 
@@ -241,7 +231,7 @@ def test_generate_nomenclature(
     exon_offset_example,
 ):
     """Test that nomenclature generation is correct."""
-    fixture_nomenclature = "reg_p@BRAF(hgnc:1097)::NM_152263.3(TPM3):e.1_8::ALK(hgnc:427)::ACGT::NC_000023.11(chr X):g.44908820_44908822(+)::v"  # noqa: E501
+    fixture_nomenclature = "reg_p@BRAF(hgnc:1097)::NM_152263.3(TPM3):e.1_8::ALK(hgnc:427)::ACGT::NC_000023.11(chr X):g.44908820_44908822(+)::v"
     nm = fusor_instance.generate_nomenclature(CategoricalFusion(**fusion_example))
     assert nm == fixture_nomenclature
     nm = fusor_instance.generate_nomenclature(CategoricalFusion(**exhaustive_example))

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,6 +1,5 @@
 """Test FUSOR tools."""
 import pytest
-
 from fusor.exceptions import IDTranslationException
 from fusor.tools import translate_identifier
 

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,5 +1,6 @@
 """Test FUSOR tools."""
 import pytest
+
 from fusor.exceptions import IDTranslationException
 from fusor.tools import translate_identifier
 


### PR DESCRIPTION
close #137 

purely stylistic change -- removes the `black` dependency and uses Ruff's formatter instead.