### PR TITLE
feat!: enable cool-seq-tool injection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "ga4gh.vrs ~=0.8.1",
     "biocommons.seqrepo",
     "gene-normalizer ~=0.1.40-dev1",
-    "cool-seq-tool ~=0.3.0-dev1",
+    "cool-seq-tool~=0.5.0",
 ]
 dynamic=["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "ga4gh.vrs ~=0.8.1",
     "biocommons.seqrepo",
     "gene-normalizer ~=0.1.40-dev1",
-    "cool-seq-tool~=0.5.0",
+    "cool-seq-tool ~=0.5.0",
 ]
 dynamic=["version"]
 

--- a/src/fusor/fusor.py
+++ b/src/fusor/fusor.py
@@ -4,9 +4,8 @@ import logging
 import re
 from urllib.parse import quote
 
-from biocommons.seqrepo import SeqRepo
 from bioutils.accessions import coerce_namespace
-from cool_seq_tool.routers import CoolSeqTool
+from cool_seq_tool.app import CoolSeqTool
 from cool_seq_tool.schemas import ResidueMode
 from ga4gh.core import ga4gh_identify
 from ga4gh.vrs import models
@@ -65,26 +64,21 @@ class FUSOR:
 
     def __init__(
         self,
-        seqrepo_data_path: str | None = None,
         gene_database: GeneDatabase | None = None,
-        uta_db_url: str | None = None,
+        cool_seq_tool: CoolSeqTool | None = None,
     ) -> None:
         """Initialize FUSOR class.
 
-        :param seqrepo_data_path: Path to SeqRepo data directory
+        :param cool_seq_tool: Cool-Seq-Tool instance
         :param gene_database: gene normalizer database instance
-        :param uta_db_url: Postgres URL for UTA
         """
         if not gene_database:
             gene_database = create_db()
         self.gene_normalizer = QueryHandler(gene_database)
 
-        cst_params = {}
-        if uta_db_url:
-            cst_params["db_url"] = uta_db_url
-        if seqrepo_data_path:
-            cst_params["sr"] = SeqRepo(seqrepo_data_path)
-        self.cool_seq_tool = CoolSeqTool(**cst_params)
+        if not cool_seq_tool:
+            cool_seq_tool = CoolSeqTool()
+        self.cool_seq_tool = cool_seq_tool
         self.seqrepo = self.cool_seq_tool.seqrepo_access.sr
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 import logging
 
 import pytest
+from cool_seq_tool.app import CoolSeqTool
 
 from fusor.fusor import FUSOR
 
@@ -30,8 +31,18 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session")
 def fusor_instance():
-    """Create test fixture for fusor object"""
-    return FUSOR()
+    """Create test fixture for fusor object
+
+    Suppresses checks for CoolSeqTool external resources. Otherwise, on CST startup,
+    it will try to check that its MANE summary file is up-to-date, which is an FTP call
+    to the NCBI servers and can hang sometimes.
+
+    If those files aren't available, create a CST instance in another session -- by
+    default, it should save files to a centralized location that this test instance can
+    access.
+    """
+    cst = CoolSeqTool(force_local_files=True)
+    return FUSOR(cool_seq_tool=cst)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
@katiestahl and I have both noticed that FUSOR tests can hang on the FTP callout to check that the MANE summary file is up to date. This PR makes `Cool-Seq-Tool` injectable and, in test, uses the `force_local_files` arg to suppress that recency check.