### PR TITLE
feat!: add reading frame to assayed fusions

### DIFF
--- a/src/fusor/examples/bcr_abl1.json
+++ b/src/fusor/examples/bcr_abl1.json
@@ -75,7 +75,7 @@
       }
     }
   ],
-  "r_frame_preserved": true,
+  "reading_frame_preserved": true,
   "critical_functional_domains": [
     {
       "type": "FunctionalDomain",

--- a/src/fusor/examples/bcr_abl1_expanded.json
+++ b/src/fusor/examples/bcr_abl1_expanded.json
@@ -110,7 +110,7 @@
       "element_genomic_end": null
     }
   ],
-  "r_frame_preserved": true,
+  "reading_frame_preserved": true,
   "critical_functional_domains": [
     {
       "type": "FunctionalDomain",

--- a/src/fusor/fusor.py
+++ b/src/fusor/fusor.py
@@ -130,7 +130,6 @@ class FUSOR:
             categorical_attributes = any(
                 [
                     "critical_functional_domains" in kwargs,
-                    "r_frame_preserved" in kwargs,
                     self._contains_element_type(
                         kwargs, StructuralElementType.MULTIPLE_POSSIBLE_GENES_ELEMENT
                     ),
@@ -166,7 +165,7 @@ class FUSOR:
         structural_elements: CategoricalFusionElements,
         regulatory_element: RegulatoryElement | None = None,
         critical_functional_domains: list[FunctionalDomain] | None = None,
-        r_frame_preserved: bool | None = None,
+        reading_frame_preserved: bool | None = None,
     ) -> CategoricalFusion:
         """Construct a categorical fusion object
         :param CategoricalFusionElements structural_elements: elements
@@ -175,7 +174,7 @@ class FUSOR:
             regulatory element
         :param Optional[List[FunctionalDomain]] critical_functional_domains: lost or preserved
             functional domains
-        :param Optional[bool] r_frame_preserved: `True` if reading frame is
+        :param Optional[bool] reading_frame_preserved: `True` if reading frame is
             preserved.  `False` otherwise
         :return: CategoricalFusion if construction successful
         :raise: FUSORParametersException if given incorrect fusion properties
@@ -184,7 +183,7 @@ class FUSOR:
             fusion = CategoricalFusion(
                 structural_elements=structural_elements,
                 critical_functional_domains=critical_functional_domains,
-                r_frame_preserved=r_frame_preserved,
+                reading_frame_preserved=reading_frame_preserved,
                 regulatory_element=regulatory_element,
             )
         except ValidationError as e:
@@ -197,6 +196,7 @@ class FUSOR:
         causative_event: CausativeEvent | None = None,
         assay: Assay | None = None,
         regulatory_element: RegulatoryElement | None = None,
+        reading_frame_preserved: bool | None = None,
     ) -> AssayedFusion:
         """Construct an assayed fusion object
         :param AssayedFusionElements structural_elements: elements constituting the
@@ -205,6 +205,8 @@ class FUSOR:
         :param Optional[Assay] assay: how knowledge of the fusion was obtained
         :param Optional[RegulatoryElement] regulatory_element: affected regulatory
             elements
+        :param Optional[bool] reading_frame_preserved: `True` if reading frame is
+            preserved.  `False` otherwise
         :return: Tuple containing optional AssayedFusion if construction successful,
             and any relevant validation warnings
         """
@@ -214,6 +216,7 @@ class FUSOR:
                 regulatory_element=regulatory_element,
                 causative_event=causative_event,
                 assay=assay,
+                reading_frame_preserved=reading_frame_preserved,
             )
         except ValidationError as e:
             raise FUSORParametersException(str(e)) from e

--- a/src/fusor/models.py
+++ b/src/fusor/models.py
@@ -444,6 +444,7 @@ class AbstractFusion(BaseModel, ABC):
     """Define Fusion class"""
 
     type: FusionType
+    reading_frame_preserved: StrictBool | None = None
     regulatory_element: RegulatoryElement | None = None
     structural_elements: list[BaseStructuralElement]
 
@@ -714,7 +715,6 @@ class CategoricalFusion(AbstractFusion):
     """
 
     type: Literal[FUSORTypes.CATEGORICAL_FUSION] = FUSORTypes.CATEGORICAL_FUSION
-    r_frame_preserved: StrictBool | None = None
     critical_functional_domains: list[FunctionalDomain] | None = None
     structural_elements: CategoricalFusionElements
 
@@ -722,7 +722,7 @@ class CategoricalFusion(AbstractFusion):
         json_schema_extra={
             "example": {
                 "type": "CategoricalFusion",
-                "r_frame_preserved": True,
+                "reading_frame_preserved": True,
                 "critical_functional_domains": [
                     {
                         "type": "FunctionalDomain",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -563,7 +563,7 @@ def fusion_example():
     """Create test fixture for a fake fusion without additional property expansion."""
     return {
         "type": "CategoricalFusion",
-        "r_frame_preserved": True,
+        "reading_frame_preserved": True,
         "critical_functional_domains": [
             {
                 "type": "FunctionalDomain",

--- a/tests/test_fusor.py
+++ b/tests/test_fusor.py
@@ -331,7 +331,7 @@ def fusion_ensg_sequence_id(templated_sequence_element_ensg):
             templated_sequence_element_ensg,
             {"type": "MultiplePossibleGenesElement"},
         ],
-        "r_frame_preserved": True,
+        "reading_frame_preserved": True,
         "regulatory_element": None,
     }
     return CategoricalFusion(**params)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -690,7 +690,7 @@ def test_fusion(
     """Test that Fusion object initializes correctly"""
     # test valid object
     fusion = CategoricalFusion(
-        r_frame_preserved=True,
+        reading_frame_preserved=True,
         critical_functional_domains=[functional_domains[0]],
         structural_elements=[transcript_segments[1], transcript_segments[2]],
         regulatory_element=regulatory_elements[0],


### PR DESCRIPTION
close #152 

there's a corresponding PR up on the docs as well 

we don't _have_ to change the field name from `r_` to `reading_` but I think it's an unnecessary contraction so now's a good time to change it, if we're up for it