### PR TITLE
fix: update structural elements with discriminator 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,8 @@ classifiers = [
 requires-python = ">=3.10"
 description = "Computable object representation and validation for gene fusions"
 license = {file = "LICENSE"}
-# pydantic is pinned to 2.4.2 for now, since there is a change in later versions that causes a validation error for test_fusion in test_fusor.py
 dependencies = [
-    "pydantic ==2.4.2",
+    "pydantic ==2.*",
     "ga4gh.vrs ~=2.0.0a10",
     "biocommons.seqrepo",
     "gene-normalizer ==0.4.0",

--- a/src/fusor/fusor.py
+++ b/src/fusor/fusor.py
@@ -25,10 +25,10 @@ from fusor.exceptions import FUSORParametersException, IDTranslationException
 from fusor.models import (
     Assay,
     AssayedFusion,
-    AssayedFusionElements,
+    AssayedFusionElement,
     BaseStructuralElement,
     CategoricalFusion,
-    CategoricalFusionElements,
+    CategoricalFusionElement,
     CausativeEvent,
     DomainStatus,
     Evidence,
@@ -158,7 +158,7 @@ class FUSOR:
 
     @staticmethod
     def categorical_fusion(
-        structure: CategoricalFusionElements,
+        structure: CategoricalFusionElement,
         regulatory_element: RegulatoryElement | None = None,
         critical_functional_domains: list[FunctionalDomain] | None = None,
         reading_frame_preserved: bool | None = None,
@@ -185,7 +185,7 @@ class FUSOR:
 
     @staticmethod
     def assayed_fusion(
-        structure: AssayedFusionElements,
+        structure: AssayedFusionElement,
         causative_event: CausativeEvent | None = None,
         assay: Assay | None = None,
         regulatory_element: RegulatoryElement | None = None,

--- a/src/fusor/fusor.py
+++ b/src/fusor/fusor.py
@@ -158,7 +158,7 @@ class FUSOR:
 
     @staticmethod
     def categorical_fusion(
-        structure: CategoricalFusionElement,
+        structure: list[CategoricalFusionElement],
         regulatory_element: RegulatoryElement | None = None,
         critical_functional_domains: list[FunctionalDomain] | None = None,
         reading_frame_preserved: bool | None = None,
@@ -185,7 +185,7 @@ class FUSOR:
 
     @staticmethod
     def assayed_fusion(
-        structure: AssayedFusionElement,
+        structure: list[AssayedFusionElement],
         causative_event: CausativeEvent | None = None,
         assay: Assay | None = None,
         regulatory_element: RegulatoryElement | None = None,

--- a/src/fusor/fusor.py
+++ b/src/fusor/fusor.py
@@ -585,7 +585,7 @@ class FUSOR:
         """
         parts = []
         element_genes = []
-        if fusion.regulatoryElement:
+        if fusion.get("regulatoryElement"):
             parts.append(
                 reg_element_nomenclature(fusion.regulatoryElement, self.seqrepo)
             )

--- a/src/fusor/fusor.py
+++ b/src/fusor/fusor.py
@@ -585,7 +585,7 @@ class FUSOR:
         """
         parts = []
         element_genes = []
-        if fusion.get("regulatoryElement"):
+        if fusion.regulatoryElement:
             parts.append(
                 reg_element_nomenclature(fusion.regulatoryElement, self.seqrepo)
             )

--- a/src/fusor/models.py
+++ b/src/fusor/models.py
@@ -555,7 +555,7 @@ class Assay(BaseModelForbidExtra):
     )
 
 
-AssayedFusionElements = Annotated[
+AssayedFusionElement = Annotated[
     TranscriptSegmentElement
     | GeneElement
     | TemplatedSequenceElement
@@ -604,7 +604,7 @@ class AssayedFusion(AbstractFusion):
     """
 
     type: Literal[FUSORTypes.ASSAYED_FUSION] = FUSORTypes.ASSAYED_FUSION
-    structure: list[AssayedFusionElements]
+    structure: list[AssayedFusionElement]
     causativeEvent: CausativeEvent | None = None
     assay: Assay | None = None
 
@@ -640,7 +640,7 @@ class AssayedFusion(AbstractFusion):
     )
 
 
-CategoricalFusionElements = Annotated[
+CategoricalFusionElement = Annotated[
     TranscriptSegmentElement
     | GeneElement
     | TemplatedSequenceElement
@@ -659,7 +659,7 @@ class CategoricalFusion(AbstractFusion):
 
     type: Literal[FUSORTypes.CATEGORICAL_FUSION] = FUSORTypes.CATEGORICAL_FUSION
     criticalFunctionalDomains: list[FunctionalDomain] | None = None
-    structure: list[CategoricalFusionElements]
+    structure: list[CategoricalFusionElement]
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/src/fusor/models.py
+++ b/src/fusor/models.py
@@ -2,7 +2,7 @@
 
 from abc import ABC
 from enum import Enum
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from cool_seq_tool.schemas import Strand
 from ga4gh.core.domain_models import Gene
@@ -14,6 +14,7 @@ from gene.schemas import CURIE
 from pydantic import (
     BaseModel,
     ConfigDict,
+    Field,
     StrictBool,
     StrictInt,
     StrictStr,
@@ -554,12 +555,13 @@ class Assay(BaseModelForbidExtra):
     )
 
 
-AssayedFusionElements = list[
+AssayedFusionElements = Annotated[
     TranscriptSegmentElement
     | GeneElement
     | TemplatedSequenceElement
     | LinkerElement
-    | UnknownGeneElement
+    | UnknownGeneElement,
+    Field(discriminator="type"),
 ]
 
 
@@ -602,7 +604,7 @@ class AssayedFusion(AbstractFusion):
     """
 
     type: Literal[FUSORTypes.ASSAYED_FUSION] = FUSORTypes.ASSAYED_FUSION
-    structure: AssayedFusionElements
+    structure: list[AssayedFusionElements]
     causativeEvent: CausativeEvent | None = None
     assay: Assay | None = None
 
@@ -638,12 +640,13 @@ class AssayedFusion(AbstractFusion):
     )
 
 
-CategoricalFusionElements = list[
+CategoricalFusionElements = Annotated[
     TranscriptSegmentElement
     | GeneElement
     | TemplatedSequenceElement
     | LinkerElement
-    | MultiplePossibleGenesElement
+    | MultiplePossibleGenesElement,
+    Field(discriminator="type"),
 ]
 
 
@@ -656,7 +659,7 @@ class CategoricalFusion(AbstractFusion):
 
     type: Literal[FUSORTypes.CATEGORICAL_FUSION] = FUSORTypes.CATEGORICAL_FUSION
     criticalFunctionalDomains: list[FunctionalDomain] | None = None
-    structure: CategoricalFusionElements
+    structure: list[CategoricalFusionElements]
 
     model_config = ConfigDict(
         json_schema_extra={


### PR DESCRIPTION
to ensure correct classes are always being validated

This fixes the validation error we were having with pydantic versions above `2.4.2`, when constructing a fusion, some of the structural elements were not being associated with the correct class type and causing validation errors (ie; a created TemplatedSequenceElement was being validated with TranscriptSegmentElement validators when calling `fusor.fusion(structure....` because pydantic was incorrectly resolving the class type or not using it at all)

This seems to be backwards compatible with other 2.x pydantic versions. (I checked with 2.8.2 (most recent) and with 2.4.2). This only won't work properly with pydantic versions before 1.8, where the discriminator was introduced.