### PR TITLE
feat: add independent nomenclature method

### DIFF
--- a/src/fusor/fusor.py
+++ b/src/fusor/fusor.py
@@ -31,7 +31,6 @@ from fusor.models import (
     CategoricalFusionElement,
     CausativeEvent,
     DomainStatus,
-    Evidence,
     FunctionalDomain,
     Fusion,
     FusionType,
@@ -45,12 +44,7 @@ from fusor.models import (
     TranscriptSegmentElement,
     UnknownGeneElement,
 )
-from fusor.nomenclature import (
-    gene_nomenclature,
-    reg_element_nomenclature,
-    templated_seq_nomenclature,
-    tx_segment_nomenclature,
-)
+from fusor.nomenclature import generate_nomenclature
 from fusor.tools import translate_identifier
 
 _logger = logging.getLogger(__name__)
@@ -583,39 +577,4 @@ class FUSOR:
         :return: string summarizing fusion in human-readable way per VICC fusion
             curation nomenclature
         """
-        parts = []
-        element_genes = []
-        if fusion.regulatoryElement:
-            parts.append(
-                reg_element_nomenclature(fusion.regulatoryElement, self.seqrepo)
-            )
-        for element in fusion.structure:
-            if isinstance(element, MultiplePossibleGenesElement):
-                parts.append("v")
-            elif isinstance(element, UnknownGeneElement):
-                parts.append("?")
-            elif isinstance(element, LinkerElement):
-                parts.append(element.linkerSequence.sequence.root)
-            elif isinstance(element, TranscriptSegmentElement):
-                if not any(
-                    [gene == element.gene.label for gene in element_genes]  # noqa: C419
-                ):
-                    parts.append(tx_segment_nomenclature(element))
-            elif isinstance(element, TemplatedSequenceElement):
-                parts.append(templated_seq_nomenclature(element, self.seqrepo))
-            elif isinstance(element, GeneElement):
-                if not any(
-                    [gene == element.gene.label for gene in element_genes]  # noqa: C419
-                ):
-                    parts.append(gene_nomenclature(element))
-            else:
-                raise ValueError
-        if (
-            isinstance(fusion, AssayedFusion)
-            and fusion.assay
-            and fusion.assay.fusionDetection == Evidence.INFERRED
-        ):
-            divider = "(::)"
-        else:
-            divider = "::"
-        return divider.join(parts)
+        return generate_nomenclature(fusion, self.seqrepo)

--- a/tests/test_nomenclature.py
+++ b/tests/test_nomenclature.py
@@ -4,7 +4,7 @@ import pytest
 from ga4gh.core.domain_models import Gene
 
 from fusor.models import AssayedFusion, CategoricalFusion, TranscriptSegmentElement
-from fusor.nomenclature import tx_segment_nomenclature
+from fusor.nomenclature import generate_nomenclature, tx_segment_nomenclature
 
 
 @pytest.fixture(scope="module")
@@ -208,53 +208,59 @@ def test_generate_nomenclature(
 ):
     """Test that nomenclature generation is correct."""
     fixture_nomenclature = "reg_p@BRAF(hgnc:1097)::NM_152263.3(TPM3):e.1_8::ALK(hgnc:427)::ACGT::NC_000023.11(chr X):g.44908820_44908822(+)::v"
-    nm = fusor_instance.generate_nomenclature(CategoricalFusion(**fusion_example))
+    nm = generate_nomenclature(
+        CategoricalFusion(**fusion_example), fusor_instance.seqrepo
+    )
     assert nm == fixture_nomenclature
-    nm = fusor_instance.generate_nomenclature(CategoricalFusion(**exhaustive_example))
+    nm = generate_nomenclature(
+        CategoricalFusion(**exhaustive_example), fusor_instance.seqrepo
+    )
     assert nm == fixture_nomenclature
 
     from fusor import examples
 
-    nm = fusor_instance.generate_nomenclature(examples.bcr_abl1)
+    nm = generate_nomenclature(examples.bcr_abl1, fusor_instance.seqrepo)
     assert nm == "NM_004327.3(BCR):e.2+182::ACTAAAGCG::NM_005157.5(ABL1):e.2-173"
 
-    nm = fusor_instance.generate_nomenclature(examples.bcr_abl1_expanded)
+    nm = generate_nomenclature(examples.bcr_abl1_expanded, fusor_instance.seqrepo)
     assert nm == "NM_004327.3(BCR):e.2+182::ACTAAAGCG::NM_005157.5(ABL1):e.2-173"
 
-    nm = fusor_instance.generate_nomenclature(examples.alk)
+    nm = generate_nomenclature(examples.alk, fusor_instance.seqrepo)
     assert nm == "v::ALK(hgnc:427)"
 
-    nm = fusor_instance.generate_nomenclature(examples.tpm3_ntrk1)
+    nm = generate_nomenclature(examples.tpm3_ntrk1, fusor_instance.seqrepo)
     assert nm == "NM_152263.3(TPM3):e.8(::)NM_002529.3(NTRK1):e.10"
 
-    nm = fusor_instance.generate_nomenclature(examples.tpm3_pdgfrb)
+    nm = generate_nomenclature(examples.tpm3_pdgfrb, fusor_instance.seqrepo)
     assert nm == "NM_152263.3(TPM3):e.1_8::NM_002609.3(PDGFRB):e.11_22"
 
-    nm = fusor_instance.generate_nomenclature(examples.ewsr1)
+    nm = generate_nomenclature(examples.ewsr1, fusor_instance.seqrepo)
     assert nm == "EWSR1(hgnc:3508)(::)?"
 
-    nm = fusor_instance.generate_nomenclature(examples.ewsr1_no_assay)
+    nm = generate_nomenclature(examples.ewsr1_no_assay, fusor_instance.seqrepo)
     assert nm == "EWSR1(hgnc:3508)::?"
 
-    nm = fusor_instance.generate_nomenclature(examples.ewsr1_no_causative_event)
+    nm = generate_nomenclature(
+        examples.ewsr1_no_causative_event, fusor_instance.seqrepo
+    )
     assert nm == "EWSR1(hgnc:3508)(::)?"
 
-    nm = fusor_instance.generate_nomenclature(examples.ewsr1_elements_only)
+    nm = generate_nomenclature(examples.ewsr1_elements_only, fusor_instance.seqrepo)
     assert nm == "EWSR1(hgnc:3508)::?"
 
-    nm = fusor_instance.generate_nomenclature(examples.igh_myc)
+    nm = generate_nomenclature(examples.igh_myc, fusor_instance.seqrepo)
     assert nm == "reg_e_EH38E3121735@IGH(hgnc:5477)::MYC(hgnc:7553)"
 
-    nm = fusor_instance.generate_nomenclature(reg_example)
+    nm = generate_nomenclature(reg_example, fusor_instance.seqrepo)
     assert nm == "reg_riboswitch@ABL1(hgnc:76)::BCR(hgnc:1014)::?"
 
-    nm = fusor_instance.generate_nomenclature(reg_location_example)
+    nm = generate_nomenclature(reg_location_example, fusor_instance.seqrepo)
     assert (
         nm
         == "reg_p_NC_000023.11(chr X):g.1462581_1534182@P2RY8(hgnc:15524)::SOX5(hgnc:11201)"
     )
 
-    nm = fusor_instance.generate_nomenclature(exon_offset_example)
+    nm = generate_nomenclature(exon_offset_example, fusor_instance.seqrepo)
     assert nm == "BRAF(hgnc:1097)::NM_002529.3(NTRK1):e.2+20"
 
 


### PR DESCRIPTION
Not sure if this is really a meaningful change, but I thought it was weird that the `nomenclatures` module contained code for generating some of the nomenclature subcomponents but not the entire nomenclature string. This PR pulls that code out of FUSOR and puts it into the nomenclature module.

As a side note, a lot of stuff in FUSOR is named very weirdly. It would be annoying to rename but we have a lot of methods that have noun phrase names rather than "doing" names.

Would like to get this merged before docs PR.