### PR TITLE
fix: attempting to subscript an object

### DIFF
--- a/src/fusor/models.py
+++ b/src/fusor/models.py
@@ -513,7 +513,7 @@ class AbstractFusion(BaseModel, ABC):
         """
         elements = values.structure
         if isinstance(elements[0], TranscriptSegmentElement):
-            if elements[0].exonEnd is None and not values["regulatoryElement"]:
+            if elements[0].exonEnd is None and not values.regulatoryElement:
                 msg = "5' TranscriptSegmentElement fusion partner must contain ending exon position"
                 raise ValueError(msg)
         elif isinstance(elements[0], LinkerElement):


### PR DESCRIPTION
So this comment: https://github.com/cancervariants/fusion-curation/pull/314#issuecomment-2309960695 seems to have uncovered this issue. I don't really know why/how this ever worked? You can see on line 514, it's implied that this is an object, so I'm not sure why on line 516 we're attempting to subscript the object. 

I could be totally off on this, but I'm going to open this PR just in case! This could be a good discussion :D 