### PR TITLE
feat!: change arriba fusion detection algorithm input parameters

### DIFF
--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -399,9 +399,9 @@ class Translator:
         :param event: An inference about the type of fusion event
         :param confidence: A metric describing the confidence of the fusion prediction
         :param direction1: A description that indicates if the transcript segment
-        starts or ends at breakpoint1
+            starts or ends at breakpoint1
         :param direction2: A description that indicates if the transcript segment
-        starts or ends at breakpoint2
+            starts or ends at breakpoint2
         :param rf: A description if the reading frame is preserved for the fusion
         :param rb: The reference build used to call the fusion
         :return: An AssayedFusion object, if construction is successful

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -304,36 +304,60 @@ async def test_arriba(
 ):
     """Test Arriba translator"""
     # Test exonic breakpoint
-    arriba_data = pl.DataFrame(
-        {
-            "#gene1": "TPM3",
-            "gene2": "PDGFRB",
-            "breakpoint1": "1:154170465",
-            "breakpoint2": "5:150126612",
-            "type": ".",
-            "confidence": "high",
-            "reading_frame": "in-frame",
-        }
-    )
+    gene1 = "TPM3"
+    gene2 = "PDGFRB"
+    strand1 = "-/-"
+    strand2 = "-/-"
+    breakpoint1 = "1:154170465"
+    breakpoint2 = "5:150126612"
+    event = "translocation"
+    confidence = "high"
+    direction1 = "upstream"
+    direction2 = "downstream"
+    rf = "in-frame"
+
     arriba_fusor = await translator_instance.from_arriba(
-        arriba_data, Assembly.GRCH38.value
+        gene1,
+        gene2,
+        strand1,
+        strand2,
+        breakpoint1,
+        breakpoint2,
+        event,
+        confidence,
+        direction1,
+        direction2,
+        rf,
+        Assembly.GRCH38.value,
     )
     assert arriba_fusor.structure == fusion_data_example.structure
 
     # Test non-exonic breakpoint
-    arriba_data_nonexonic = pl.DataFrame(
-        {
-            "#gene1": "TPM3",
-            "gene2": "PDGFRB",
-            "breakpoint1": "1:154173078",
-            "breakpoint2": "5:150127173",
-            "type": ".",
-            "confidence": "high",
-            "reading_frame": "in-frame",
-        }
-    )
+    gene1 = "TPM3"
+    gene2 = "PDGFRB"
+    strand1 = "-/-"
+    strand2 = "-/-"
+    breakpoint1 = "1:154173078"
+    breakpoint2 = "5:150127173"
+    event = "translocation"
+    confidence = "high"
+    direction1 = "upstream"
+    direction2 = "downstream"
+    rf = "in-frame"
+
     arriba_fusor_nonexonic = await translator_instance.from_arriba(
-        arriba_data_nonexonic, Assembly.GRCH38.value
+        gene1,
+        gene2,
+        strand1,
+        strand2,
+        breakpoint1,
+        breakpoint2,
+        event,
+        confidence,
+        direction1,
+        direction2,
+        rf,
+        Assembly.GRCH38.value,
     )
     assert arriba_fusor_nonexonic.structure == fusion_data_example_nonexonic.structure
 

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -312,8 +312,8 @@ async def test_arriba(
     breakpoint2 = "5:150126612"
     event = "translocation"
     confidence = "high"
-    direction1 = "upstream"
-    direction2 = "downstream"
+    direction1 = "dowstream"
+    direction2 = "upstream"
     rf = "in-frame"
 
     arriba_fusor = await translator_instance.from_arriba(
@@ -341,8 +341,8 @@ async def test_arriba(
     breakpoint2 = "5:150127173"
     event = "translocation"
     confidence = "high"
-    direction1 = "upstream"
-    direction2 = "downstream"
+    direction1 = "dowstream"
+    direction2 = "upstream"
     rf = "in-frame"
 
     arriba_fusor_nonexonic = await translator_instance.from_arriba(


### PR DESCRIPTION
Closes #203  

Notes: This translator includes a variable that tells us if a transcript segment starts or ends at breakpoint, so new logic was added to take this into account. 

From Arriba:
direction1 and direction2 : These columns indicate the orientation of the fusion breakpoints. A value of downstream means that the fusion partner is fused downstream of the breakpoint, i.e., at a coordinate higher than the breakpoint.In other words, the supporting split reads are right-clipped. A value of upstream means the partner is fused at a coordinate lower than the breakpoint. In other words, the supporting split reads are left-clipped. When the prediction of the strands or of the 5' gene fails, this information gives insight into which parts of the fused genes are retained in the fusion.

This required the strand variable to be re-added as this indicates the direction of transcription and allows us to choose whether we should choose `seg_start_genomic` or `seg_end_genomic` for a breakpoint.