### PR TITLE
feat!: change CICERO fusion detection algorithm input parameters

### DIFF
--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -480,8 +480,8 @@ class Translator:
         :param chr_3prime: The chromosome for the 3' partner
         :param pos_5prime: The genomic breakpoint for the 5' partner
         :param pos_3prime: The genomic breakpoint for the 3' partner
-        :param sv_ort: Whether the mapping orientation of assembled contig has
-            confident biological meaning
+        :param sv_ort: Whether the mapping orientation of assembled contig (driven by
+            structural variation) has confident biological meaning
         :param event_type: The structural variation event that created the called fusion
         :param rb: The reference build used to call the fusion
         :return: An AssayedFusion object, if construction is successful

--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -487,7 +487,7 @@ class Translator:
         :return: An AssayedFusion object, if construction is successful
         """
         # Check if gene symbols have valid formatting. CICERO can output two or more
-        # gene symbols for `gene_a` or `gene_b`, which are separated by a column. As
+        # gene symbols for `gene_5prime` or `gene_3prime`, which are separated by a column. As
         # there is not a precise way to resolve this ambiguity, we do not process
         # these events
         if "," in gene_5prime or "," in gene_3prime:

--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -487,7 +487,7 @@ class Translator:
         :return: An AssayedFusion object, if construction is successful
         """
         # Check if gene symbols have valid formatting. CICERO can output two or more
-        # gene symbols for `gene_5prime` or `gene_3prime`, which are separated by a column. As
+        # gene symbols for `gene_5prime` or `gene_3prime`, which are separated by a comma. As
         # there is not a precise way to resolve this ambiguity, we do not process
         # these events
         if "," in gene_5prime or "," in gene_3prime:

--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -462,24 +462,24 @@ class Translator:
 
     async def from_cicero(
         self,
-        gene_a: str,
-        gene_b: str,
-        chr_a: str,
-        chr_b: str,
-        pos_a: int,
-        pos_b: int,
+        gene_5prime: str,
+        gene_3prime: str,
+        chr_5prime: str,
+        chr_3prime: str,
+        pos_5prime: int,
+        pos_3prime: int,
         sv_ort: str,
         event_type: str,
         rb: Assembly,
     ) -> AssayedFusion | str:
         """Parse CICERO output to create AssayedFusion object
 
-        :param geneA: The gene symbol for the 5' partner
-        :param geneB: The gene symbol for the 3' partner
-        :param chrA: The chromosome for the 5' partner
-        :param chrB: The chromosome for the 3' partner
-        :param posA: The genomic breakpoint for the 5' partner
-        :param posB: The genomic breakpoint for the 3' partner
+        :param gene_5prime: The gene symbol for the 5' partner
+        :param gene_3prime: The gene symbol for the 3' partner
+        :param chr_5prime: The chromosome for the 5' partner
+        :param chr_3prime: The chromosome for the 3' partner
+        :param pos_5prime: The genomic breakpoint for the 5' partner
+        :param pos_3prime: The genomic breakpoint for the 3' partner
         :param sv_ort: Whether the mapping orientation of assembled contig has
             confident biological meaning
         :param event_type: The structural variation event that created the called fusion
@@ -490,7 +490,7 @@ class Translator:
         # gene symbols for `gene_a` or `gene_b`, which are separated by a column. As
         # there is not a precise way to resolve this ambiguity, we do not process
         # these events
-        if "," in gene_a or "," in gene_b:
+        if "," in gene_5prime or "," in gene_3prime:
             msg = "Ambiguous gene symbols are reported by CICERO for at least one of the fusion partners"
             _logger.warning(msg)
             return msg
@@ -502,21 +502,21 @@ class Translator:
             _logger.warning(msg)
             return msg
 
-        gene_5prime = self._get_gene_element(gene_a, "cicero")[0].gene.label
-        gene_3prime = self._get_gene_element(gene_b, "cicero")[0].gene.label
+        gene_5prime = self._get_gene_element(gene_5prime, "cicero")[0].gene.label
+        gene_3prime = self._get_gene_element(gene_3prime, "cicero")[0].gene.label
 
         tr_5prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,
-            genomic_ac=self._get_genomic_ac(chr_a, rb),
-            seg_end_genomic=pos_a,
+            genomic_ac=self._get_genomic_ac(chr_5prime, rb),
+            seg_end_genomic=pos_5prime,
             gene=gene_5prime,
             get_nearest_transcript_junction=True,
         )
 
         tr_3prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,
-            genomic_ac=self._get_genomic_ac(chr_b, rb),
-            seg_start_genomic=pos_b,
+            genomic_ac=self._get_genomic_ac(chr_3prime, rb),
+            seg_start_genomic=pos_3prime,
             gene=gene_3prime,
             get_nearest_transcript_junction=True,
         )

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -368,38 +368,102 @@ async def test_cicero(
 ):
     """Test CICERO translator"""
     # Test exonic breakpoint
-    cicero_data = pl.DataFrame(
-        {
-            "geneA": "TPM3",
-            "geneB": "PDGFRB",
-            "chrA": "1",
-            "posA": "154170465",
-            "chrB": "5",
-            "posB": "150126612",
-            "type": "CTX",
-        }
-    )
+    gene_a = "TPM3"
+    gene_b = "PDGFRB"
+    chr_a = "1"
+    chr_b = "5"
+    pos_a = 154170465
+    pos_b = 150126612
+    sv_ort = ">"
+    event_type = "CTX"
+
     cicero_fusor = await translator_instance.from_cicero(
-        cicero_data, Assembly.GRCH38.value
+        gene_a,
+        gene_b,
+        chr_a,
+        chr_b,
+        pos_a,
+        pos_b,
+        sv_ort,
+        event_type,
+        Assembly.GRCH38.value,
     )
     assert cicero_fusor.structure == fusion_data_example.structure
 
     # Test non-exonic breakpoint
-    cicero_data_nonexonic = pl.DataFrame(
-        {
-            "geneA": "TPM3",
-            "geneB": "PDGFRB",
-            "chrA": "1",
-            "posA": "154173078",
-            "chrB": "5",
-            "posB": "150127173",
-            "type": "CTX",
-        }
-    )
+    gene_a = "TPM3"
+    gene_b = "PDGFRB"
+    chr_a = "1"
+    chr_b = "5"
+    pos_a = 154173078
+    pos_b = 150127173
+    sv_ort = ">"
+    event_type = "CTX"
+
     cicero_fusor_nonexonic = await translator_instance.from_cicero(
-        cicero_data_nonexonic, Assembly.GRCH38.value
+        gene_a,
+        gene_b,
+        chr_a,
+        chr_b,
+        pos_a,
+        pos_b,
+        sv_ort,
+        event_type,
+        Assembly.GRCH38.value,
     )
     assert cicero_fusor_nonexonic.structure == fusion_data_example_nonexonic.structure
+
+    # Test case where the called fusion does not have confident biological meaning
+    gene_a = "TPM3"
+    gene_b = "PDGFRB"
+    chr_a = "1"
+    chr_b = "5"
+    pos_a = 154173078
+    pos_b = 150127173
+    sv_ort = "?"
+    event_type = "CTX"
+
+    non_confident_bio = await translator_instance.from_cicero(
+        gene_a,
+        gene_b,
+        chr_a,
+        chr_b,
+        pos_a,
+        pos_b,
+        sv_ort,
+        event_type,
+        Assembly.GRCH38.value,
+    )
+    assert (
+        non_confident_bio
+        == "CICERO annotation indicates that this event does not have confident biological meaning"
+    )
+
+    # Test case where multiple gene symbols are reported for a fusion partner
+    gene_a = "TPM3"
+    gene_b = "PDGFRB,PDGFRB-FGFR4,FGFR4"
+    chr_a = "1"
+    chr_b = "5"
+    pos_a = 154173078
+    pos_b = 150127173
+    sv_ort = "?"
+    event_type = "CTX"
+
+    multiple_genes_fusion_partner = await translator_instance.from_cicero(
+        gene_a,
+        gene_b,
+        chr_a,
+        chr_b,
+        pos_a,
+        pos_b,
+        sv_ort,
+        event_type,
+        Assembly.GRCH38.value,
+    )
+    assert (
+        multiple_genes_fusion_partner
+        == "Ambiguous gene symbols are reported by CICERO for at least one of the fusion partners"
+    )
 
 
 @pytest.mark.asyncio()

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -368,22 +368,22 @@ async def test_cicero(
 ):
     """Test CICERO translator"""
     # Test exonic breakpoint
-    gene_a = "TPM3"
-    gene_b = "PDGFRB"
-    chr_a = "1"
-    chr_b = "5"
-    pos_a = 154170465
-    pos_b = 150126612
+    gene_5prime = "TPM3"
+    gene_3prime = "PDGFRB"
+    chr_5prime = "1"
+    chr_3prime = "5"
+    pos_5prime = 154170465
+    pos_3prime = 150126612
     sv_ort = ">"
     event_type = "CTX"
 
     cicero_fusor = await translator_instance.from_cicero(
-        gene_a,
-        gene_b,
-        chr_a,
-        chr_b,
-        pos_a,
-        pos_b,
+        gene_5prime,
+        gene_3prime,
+        chr_5prime,
+        chr_3prime,
+        pos_5prime,
+        pos_3prime,
         sv_ort,
         event_type,
         Assembly.GRCH38.value,
@@ -391,22 +391,22 @@ async def test_cicero(
     assert cicero_fusor.structure == fusion_data_example.structure
 
     # Test non-exonic breakpoint
-    gene_a = "TPM3"
-    gene_b = "PDGFRB"
-    chr_a = "1"
-    chr_b = "5"
-    pos_a = 154173078
-    pos_b = 150127173
+    gene_5prime = "TPM3"
+    gene_3prime = "PDGFRB"
+    chr_5prime = "1"
+    chr_3prime = "5"
+    pos_5prime = 154173078
+    pos_3prime = 150127173
     sv_ort = ">"
     event_type = "CTX"
 
     cicero_fusor_nonexonic = await translator_instance.from_cicero(
-        gene_a,
-        gene_b,
-        chr_a,
-        chr_b,
-        pos_a,
-        pos_b,
+        gene_5prime,
+        gene_3prime,
+        chr_5prime,
+        chr_3prime,
+        pos_5prime,
+        pos_3prime,
         sv_ort,
         event_type,
         Assembly.GRCH38.value,
@@ -414,22 +414,22 @@ async def test_cicero(
     assert cicero_fusor_nonexonic.structure == fusion_data_example_nonexonic.structure
 
     # Test case where the called fusion does not have confident biological meaning
-    gene_a = "TPM3"
-    gene_b = "PDGFRB"
-    chr_a = "1"
-    chr_b = "5"
-    pos_a = 154173078
-    pos_b = 150127173
+    gene_5prime = "TPM3"
+    gene_3prime = "PDGFRB"
+    chr_5prime = "1"
+    chr_3prime = "5"
+    pos_5prime = 154173078
+    pos_3prime = 150127173
     sv_ort = "?"
     event_type = "CTX"
 
     non_confident_bio = await translator_instance.from_cicero(
-        gene_a,
-        gene_b,
-        chr_a,
-        chr_b,
-        pos_a,
-        pos_b,
+        gene_5prime,
+        gene_3prime,
+        chr_5prime,
+        chr_3prime,
+        pos_5prime,
+        pos_3prime,
         sv_ort,
         event_type,
         Assembly.GRCH38.value,
@@ -440,22 +440,22 @@ async def test_cicero(
     )
 
     # Test case where multiple gene symbols are reported for a fusion partner
-    gene_a = "TPM3"
-    gene_b = "PDGFRB,PDGFRB-FGFR4,FGFR4"
-    chr_a = "1"
-    chr_b = "5"
-    pos_a = 154173078
-    pos_b = 150127173
+    gene_5prime = "TPM3"
+    gene_3prime = "PDGFRB,PDGFRB-FGFR4,FGFR4"
+    chr_5prime = "1"
+    chr_3prime = "5"
+    pos_5prime = 154173078
+    pos_3prime = 150127173
     sv_ort = "?"
     event_type = "CTX"
 
     multiple_genes_fusion_partner = await translator_instance.from_cicero(
-        gene_a,
-        gene_b,
-        chr_a,
-        chr_b,
-        pos_a,
-        pos_b,
+        gene_5prime,
+        gene_3prime,
+        chr_5prime,
+        chr_3prime,
+        pos_5prime,
+        pos_3prime,
         sv_ort,
         event_type,
         Assembly.GRCH38.value,


### PR DESCRIPTION
closes #205 

- Add checks for examining if the gene fusion event has biological meaning (using the `sv_ort` column) and if multiple gene symbols are listed for a fusion partner (one gene symbol is expected)
- The documentation/associated metadata does not highlight any good ways to resolve this ambiguity, so for now I added code to skip fusion calls where this happens