### PR TITLE
fix: Add gene symbol check in translator methods

### DIFF
--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -262,6 +262,9 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
+
         five_prime = left_breakpoint.split(":")
         three_prime = right_breakpoint.split(":")
 
@@ -314,6 +317,10 @@ class Translator:
         gene_3prime_element = self._get_gene_element(
             three_prime_partner, Caller.FUSION_CATCHER
         )
+        if not self._fusion_symbol_check(
+            gene_5prime_element.gene.label, gene_3prime_element.gene.label
+        ):
+            return None
 
         five_prime = five_prime_fusion_point.split(":")
         three_prime = three_prime_fusion_point.split(":")
@@ -352,6 +359,9 @@ class Translator:
         gene2 = fmap_row.get_column("KnownGene2").item()
         gene_5prime = self._get_gene_element(gene1, "fusion_map").gene.label
         gene_3prime = self._get_gene_element(gene2, "fusion_map").gene.label
+
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,
@@ -431,6 +441,9 @@ class Translator:
         gene_3prime_element = self._get_gene_element(gene2, "arriba")
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
+
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
 
         strand1 = strand1.split("/")[1]  # Determine strand that is transcribed
         strand2 = strand2.split("/")[1]  # Determine strand that is transcribed
@@ -527,6 +540,9 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
+
         tr_5prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,
             genomic_ac=self._get_genomic_ac(chr_5prime, rb),
@@ -577,6 +593,9 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
+
         tr_5prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,
             genomic_ac=self._get_genomic_ac(mapsplice_row[0].split("~")[0], rb),
@@ -623,6 +642,9 @@ class Translator:
         gene_3prime_element = self._get_gene_element(gene_3prime, "enfusion")
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
+
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,
@@ -677,6 +699,9 @@ class Translator:
         gene_3prime_element = self._get_gene_element(site2_hugo, "genie")
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
+
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,

--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -141,7 +141,9 @@ class Translator:
         ge = self.fusor.gene_element(gene=gene)
         return ge[0] if ge[0] else self._get_gene_element_unnormalized(gene)
 
-    def _fusion_symbol_check(self, gene_5prime: str, gene_3prime: str) -> bool:
+    def _are_fusion_partners_different(
+        self, gene_5prime: str, gene_3prime: str
+    ) -> bool:
         """Check if the normalized gene symbols for the two fusion partners
         are different. If not, this event is not a fusion
 
@@ -205,7 +207,7 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
@@ -262,7 +264,7 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         five_prime = left_breakpoint.split(":")
@@ -317,7 +319,7 @@ class Translator:
         gene_3prime_element = self._get_gene_element(
             three_prime_partner, Caller.FUSION_CATCHER
         )
-        if not self._fusion_symbol_check(
+        if not self._are_fusion_partners_different(
             gene_5prime_element.gene.label, gene_3prime_element.gene.label
         ):
             return None
@@ -360,7 +362,7 @@ class Translator:
         gene_5prime = self._get_gene_element(gene1, "fusion_map").gene.label
         gene_3prime = self._get_gene_element(gene2, "fusion_map").gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
@@ -442,7 +444,7 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         strand1 = strand1.split("/")[1]  # Determine strand that is transcribed
@@ -540,7 +542,7 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
@@ -593,7 +595,7 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
@@ -643,7 +645,7 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
@@ -700,7 +702,7 @@ class Translator:
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
 
-        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+        if not self._are_fusion_partners_different(gene_5prime, gene_3prime):
             return None
 
         tr_5prime = await self.fusor.transcript_segment_element(

--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -141,6 +141,21 @@ class Translator:
         ge = self.fusor.gene_element(gene=gene)
         return ge[0] if ge[0] else self._get_gene_element_unnormalized(gene)
 
+    def _fusion_symbol_check(self, gene_5prime: str, gene_3prime: str) -> bool:
+        """Check if the normalized gene symbols for the two fusion partners
+        are different. If not, this event is not a fusion
+
+        :param gene_5prime: The 5' gene partner
+        :param gene_3prime: The 3' gene partner
+        :return ``True`` if the gene symbols are different, ``False`` if not
+        """
+        if gene_5prime != gene_3prime:
+            return True
+        _logger.error(
+            "The supplied fusion is not valid as the two fusion partners are the same"
+        )
+        return False
+
     def _get_genomic_ac(self, chrom: str, build: Assembly) -> str:
         """Return a RefSeq genomic accession given a chromosome and a reference build
 
@@ -189,6 +204,9 @@ class Translator:
         gene_3prime_element = self._get_gene_element(genes[1], Caller.JAFFA)
         gene_5prime = gene_5prime_element.gene.label
         gene_3prime = gene_3prime_element.gene.label
+
+        if not self._fusion_symbol_check(gene_5prime, gene_3prime):
+            return None
 
         tr_5prime = await self.fusor.transcript_segment_element(
             tx_to_genomic_coords=False,

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -115,6 +115,15 @@ def test_gene_element_arriba(translator_instance):
     assert gene.gene.label == "MIR3672"
 
 
+def test_valid_fusion_partners(translator_instance):
+    """Test that the fusion partners supplied to the translator are different"""
+    partners_check = translator_instance._fusion_symbol_check("BCR", "ABL1")
+    assert partners_check
+
+    partners_check = translator_instance._fusion_symbol_check("BCR", "BCR")
+    assert not partners_check
+
+
 @pytest.mark.asyncio()
 async def test_jaffa(
     fusion_data_example, fusion_data_example_nonexonic, translator_instance

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -117,10 +117,10 @@ def test_gene_element_arriba(translator_instance):
 
 def test_valid_fusion_partners(translator_instance):
     """Test that the fusion partners supplied to the translator are different"""
-    partners_check = translator_instance._fusion_symbol_check("BCR", "ABL1")
+    partners_check = translator_instance._are_fusion_partners_different("BCR", "ABL1")
     assert partners_check
 
-    partners_check = translator_instance._fusion_symbol_check("BCR", "BCR")
+    partners_check = translator_instance._are_fusion_partners_different("BCR", "BCR")
     assert not partners_check
 
 


### PR DESCRIPTION
closes #213 

Once the gene fusion partners are normalized, check to ensure that the resulting symbols are different. The VICC specification requires the partners to be different to be a valid fusion.