### PR TITLE
feat: Add new metadata classes for AssayedFusion events

### DIFF
--- a/src/fusor/models.py
+++ b/src/fusor/models.py
@@ -36,6 +36,10 @@ class FUSORTypes(str, Enum):
     GENE_ELEMENT = "GeneElement"
     UNKNOWN_GENE_ELEMENT = "UnknownGeneElement"
     MULTIPLE_POSSIBLE_GENES_ELEMENT = "MultiplePossibleGenesElement"
+    BREAKPOINT_COVERAGE = "BreakpointCoverage"
+    CONTIG_SEQUENCE = "ContigSequence"
+    SPLIT_READS = "SplitReads"
+    SPANNING_READS = "SpanningReads"
     REGULATORY_ELEMENT = "RegulatoryElement"
     CATEGORICAL_FUSION = "CategoricalFusion"
     ASSAYED_FUSION = "AssayedFusion"
@@ -112,6 +116,70 @@ class BaseStructuralElement(ABC, BaseModel):
     type: StructuralElementType
 
 
+class BreakpointCoverage(BaseStructuralElement):
+    """Define BreakpointCoverage class.
+
+    This class models breakpoint coverage, or the number of fragments
+    that are retained near the breakpoint for a fusion partner
+    """
+
+    type: Literal[FUSORTypes.BREAKPOINT_COVERAGE] = FUSORTypes.BREAKPOINT_COVERAGE
+    fragmentCoverage: int
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {"type": "BreakpointCoverage", "fragmentCoverage": 180}
+        }
+    )
+
+
+class ContigSequence(BaseStructuralElement):
+    """Define ContigSequence class.
+
+    This class models the assembled contig sequence that supports the reported fusion
+    event
+    """
+
+    type: Literal[FUSORTypes.CONTIG_SEQUENCE] = FUSORTypes.CONTIG_SEQUENCE
+    contig: str
+
+    model_config = ConfigDict(
+        json_schema_extra={
+            "example": {"type": "ContigSequence", "contig": "GTACTACTGATCTAGCATCTAGTA"}
+        }
+    )
+
+
+class SplitReads(BaseStructuralElement):
+    """Define SplitReads class.
+
+    This class models the number of reads that cover the junction bewteen the
+    detected partners in the fusion
+    """
+
+    type: Literal[FUSORTypes.SPLIT_READS] = FUSORTypes.SPLIT_READS
+    splitReads: int
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"type": "SplitReads", "splitReads": 100}}
+    )
+
+
+class SpanningReads(BaseStructuralElement):
+    """Define Spanning Reads class.
+
+    This class models the number of pairs of reads that support the reported fusion
+    event
+    """
+
+    type: Literal[FUSORTypes.SPANNING_READS] = FUSORTypes.SPANNING_READS
+    spanningReads: int
+
+    model_config = ConfigDict(
+        json_schema_extra={"example": {"type": "SpanningReads", "spanningReads": 100}}
+    )
+
+
 class TranscriptSegmentElement(BaseStructuralElement):
     """Define TranscriptSegment class"""
 
@@ -126,6 +194,7 @@ class TranscriptSegmentElement(BaseStructuralElement):
     gene: Gene
     elementGenomicStart: SequenceLocation | None = None
     elementGenomicEnd: SequenceLocation | None = None
+    coverage: BreakpointCoverage | None = None
 
     @model_validator(mode="before")
     def check_exons(cls, values):
@@ -571,7 +640,8 @@ AssayedFusionElement = Annotated[
     | GeneElement
     | TemplatedSequenceElement
     | LinkerElement
-    | UnknownGeneElement,
+    | UnknownGeneElement
+    | ContigSequence,
     Field(discriminator="type"),
 ]
 
@@ -620,6 +690,7 @@ class AssayedFusion(AbstractFusion):
     structure: list[AssayedFusionElement]
     causativeEvent: CausativeEvent | None = None
     assay: Assay | None = None
+    contig: ContigSequence | None = None
 
     model_config = ConfigDict(
         json_schema_extra={

--- a/src/fusor/models.py
+++ b/src/fusor/models.py
@@ -18,6 +18,7 @@ from pydantic import (
     StrictBool,
     StrictInt,
     StrictStr,
+    StringConstraints,
     model_validator,
 )
 
@@ -124,7 +125,7 @@ class BreakpointCoverage(BaseStructuralElement):
     """
 
     type: Literal[FUSORTypes.BREAKPOINT_COVERAGE] = FUSORTypes.BREAKPOINT_COVERAGE
-    fragmentCoverage: int
+    fragmentCoverage: int = Field(ge=0)
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -141,7 +142,10 @@ class ContigSequence(BaseStructuralElement):
     """
 
     type: Literal[FUSORTypes.CONTIG_SEQUENCE] = FUSORTypes.CONTIG_SEQUENCE
-    contig: str
+    contig: Annotated[
+        str,
+        StringConstraints(strip_whitespace=True, to_upper=True, pattern=r"^[ACGT]+$"),
+    ]
 
     model_config = ConfigDict(
         json_schema_extra={
@@ -158,7 +162,7 @@ class SplitReads(BaseStructuralElement):
     """
 
     type: Literal[FUSORTypes.SPLIT_READS] = FUSORTypes.SPLIT_READS
-    splitReads: int
+    splitReads: int = Field(ge=0)
 
     model_config = ConfigDict(
         json_schema_extra={"example": {"type": "SplitReads", "splitReads": 100}}
@@ -173,7 +177,7 @@ class SpanningReads(BaseStructuralElement):
     """
 
     type: Literal[FUSORTypes.SPANNING_READS] = FUSORTypes.SPANNING_READS
-    spanningReads: int
+    spanningReads: int = Field(ge=0)
 
     model_config = ConfigDict(
         json_schema_extra={"example": {"type": "SpanningReads", "spanningReads": 100}}

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,14 +8,18 @@ from fusor.models import (
     AbstractFusion,
     Assay,
     AssayedFusion,
+    BreakpointCoverage,
     CategoricalFusion,
     CausativeEvent,
+    ContigSequence,
     EventType,
     FunctionalDomain,
     GeneElement,
     LinkerElement,
     MultiplePossibleGenesElement,
     RegulatoryElement,
+    SpanningReads,
+    SplitReads,
     TemplatedSequenceElement,
     TranscriptSegmentElement,
     UnknownGeneElement,
@@ -609,6 +613,54 @@ def test_mult_gene_element():
     with pytest.raises(ValidationError) as exc_info:
         assert MultiplePossibleGenesElement(type="unknown_gene")
     msg = "Input should be <FUSORTypes.MULTIPLE_POSSIBLE_GENES_ELEMENT: 'MultiplePossibleGenesElement'>"
+    check_validation_error(exc_info, msg)
+
+
+def test_coverage():
+    """Test that BreakpointCoverage class initializes correctly"""
+    test_coverage = BreakpointCoverage(fragmentCoverage=100)
+    assert test_coverage.fragmentCoverage == 100
+
+    # test enum validation
+    with pytest.raises(ValidationError) as exc_info:
+        assert BreakpointCoverage(type="coverage")
+    msg = "Input should be <FUSORTypes.BREAKPOINT_COVERAGE: 'BreakpointCoverage'>"
+    check_validation_error(exc_info, msg)
+
+
+def test_contig():
+    """Test that Contig class initializes correctly"""
+    test_contig = ContigSequence(contig="GTATACTATGATCAGT")
+    assert test_contig.contig == "GTATACTATGATCAGT"
+
+    # test enum validation
+    with pytest.raises(ValidationError) as exc_info:
+        assert ContigSequence(type="contig")
+    msg = "Input should be <FUSORTypes.CONTIG_SEQUENCE: 'ContigSequence'>"
+    check_validation_error(exc_info, msg)
+
+
+def test_split_reads():
+    """Test that SplitReads class initializes correctly"""
+    test_split_reads = SplitReads(splitReads=97)
+    assert test_split_reads.splitReads == 97
+
+    # test enum validation
+    with pytest.raises(ValidationError) as exc_info:
+        assert SplitReads(type="splitreads")
+    msg = "Input should be <FUSORTypes.SPLIT_READS: 'SplitReads'>"
+    check_validation_error(exc_info, msg)
+
+
+def test_spanning_reads():
+    """Test that SpanningReads class initializes correctly"""
+    test_spanning_reads = SpanningReads(spanningReads=97)
+    assert test_spanning_reads.spanningReads == 97
+
+    # test enum validation
+    with pytest.raises(ValidationError) as exc_info:
+        assert SpanningReads(type="spanningreads")
+    msg = "Input should be <FUSORTypes.SPANNING_READS: 'SpanningReads'>"
     check_validation_error(exc_info, msg)
 
 


### PR DESCRIPTION
closes #218 

I'm pretty sure that the `BreakpointCoverage` class belongs at the `TranscriptSegment` level and that the `ContigSequence` class belongs at the `AssayedFusion` level. I'm unsure if the Split and Spanning Reads class would belong at the transcript or fusion level (may depend on how this data is reported by the specific fusion detection algorithm). I will go over this question with @ahwagner and modify in a separate PR