### PR TITLE
feat!: Add pydantic classes for output from fusion callers

### DIFF
--- a/src/fusor/fusion_caller_models.py
+++ b/src/fusor/fusion_caller_models.py
@@ -1,0 +1,54 @@
+"""Schemas for fusion callers used in translator.py"""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class BaseModelForbidExtra(BaseModel, extra="forbid"):
+    """Base Pydantic model class with extra values forbidden."""
+
+
+class FusionCallerTypes(str, Enum):
+    """Define FusionCaller type values"""
+
+    JAFFA = "JAFFA"
+
+
+class JAFFA(BaseModel):
+    """Define parameters for JAFFA model"""
+
+    type: Literal[FusionCallerTypes.JAFFA] = FusionCallerTypes.JAFFA
+    fusion_genes: str = Field(
+        ..., description="A string containing the two fusion partners"
+    )
+    chrom1: str = Field(
+        ..., description="The chromosome indicated in the chrom1 column"
+    )
+    base1: int = Field(
+        ..., description="The genomic position indicated in the base1 column"
+    )
+    chrom2: str = Field(
+        ..., description="The chromosome indicated in the chrom2 column"
+    )
+    base2: int = Field(
+        ..., description="The genomic position indicated in the base2 column"
+    )
+    rearrangement: bool = Field(
+        ..., description=" A boolean indicating if a rearrangement occured"
+    )
+    classification: str = Field(
+        ..., description="The classification associated with the called fusion"
+    )
+    inframe: bool = Field(
+        ..., description="A boolean indicating if the fusion occurred in-frame"
+    )
+    spanning_reads: int = Field(
+        ...,
+        description="The number of deteced reads that span the junction bewtween the two transcript. Although described as spanning reads, this aligns with our defintion of split reads i.e. reads that have sequence belonging to the fusion partners",
+    )
+    spanning_pairs: int = Field(
+        ...,
+        description="The number of detected reads that align entirely on either side of the breakpoint",
+    )

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -4,6 +4,7 @@ import polars as pl
 import pytest
 from cool_seq_tool.schemas import Assembly, CoordinateType
 
+from fusor.fusion_caller_models import JAFFA
 from fusor.models import (
     AnchoredReads,
     AssayedFusion,
@@ -148,28 +149,21 @@ async def test_jaffa(
 ):
     """Test JAFFA translator"""
     # Test exonic breakpoint
-    fusion_genes = "TPM3:PDGFRB"
-    chrom1 = "chr1"
-    base1 = 154170465
-    chrom2 = "chr5"
-    base2 = 150126612
-    rearrangement = True
-    classification = "HighConfidence"
-    inframe = True
-    spanning_reads = 100
-    spanning_pairs = 80
+    jaffa = JAFFA(
+        fusion_genes="TPM3:PDGFRB",
+        chrom1="chr1",
+        base1=154170465,
+        chrom2="chr5",
+        base2=150126612,
+        rearrangement=True,
+        classification="HighConfidence",
+        inframe=True,
+        spanning_reads=100,
+        spanning_pairs=80,
+    )
 
     jaffa_fusor = await translator_instance.from_jaffa(
-        fusion_genes,
-        chrom1,
-        base1,
-        chrom2,
-        base2,
-        rearrangement,
-        classification,
-        inframe,
-        spanning_reads,
-        spanning_pairs,
+        jaffa,
         CoordinateType.INTER_RESIDUE.value,
         Assembly.GRCH38.value,
     )
@@ -182,28 +176,21 @@ async def test_jaffa(
     assert jaffa_fusor.readData == fusion_data_example.readData
 
     # Test non-exonic breakpoint
-    fusion_genes = "TPM3:PDGFRB"
-    chrom1 = "chr1"
-    base1 = 154173079
-    chrom2 = "chr5"
-    base2 = 150127173
-    rearrangement = True
-    classification = "HighConfidence"
-    inframe = True
-    spanning_reads = 100
-    spanning_pairs = 80
+    jaffa = JAFFA(
+        fusion_genes="TPM3:PDGFRB",
+        chrom1="chr1",
+        base1=154173079,
+        chrom2="chr5",
+        base2=150127173,
+        rearrangement=True,
+        classification="HighConfidence",
+        inframe=True,
+        spanning_reads=100,
+        spanning_pairs=80,
+    )
 
     jaffa_fusor_nonexonic = await translator_instance.from_jaffa(
-        fusion_genes,
-        chrom1,
-        base1,
-        chrom2,
-        base2,
-        rearrangement,
-        classification,
-        inframe,
-        spanning_reads,
-        spanning_pairs,
+        jaffa,
         CoordinateType.RESIDUE.value,
         Assembly.GRCH38.value,
     )


### PR DESCRIPTION
closes #227 

This PR creates pydantic classes for each fusion caller in a new file called `fusion_caller_models.py`. These classes are then called in `translator.py`