### PR TITLE
feat: Add notebook for demonstrating evidence matching workflow

### DIFF
--- a/src/fusor/notebooks/fusion_evidence_matching.ipynb
+++ b/src/fusor/notebooks/fusion_evidence_matching.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "c75a5a00",
+   "metadata": {},
+   "source": [
+    "# Notebook for demonstrating evidence matching between assayed fusions and categorical fusions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "4ec41cf4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "from os import environ\n",
+    "\n",
+    "warnings.filterwarnings(\"ignore\")\n",
+    "\n",
+    "environ[\"GENE_NORM_DB_URL\"] = \"postgresql://postgres@localhost:5432/gene_normalizer\"\n",
+    "environ[\"UTA_DB_URL\"] = \"postgresql://uta_admin:uta@localhost:5432/uta/uta_20240523b\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3c78c9c4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from civicpy import civic\n",
+    "\n",
+    "from fusor.fusor import FUSOR\n",
+    "from fusor.translator import Translator\n",
+    "\n",
+    "fusor = FUSOR()\n",
+    "translator = Translator(fusor=fusor)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "39397589",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Generate KIF5B::RET AssayedFusion from StarFusion file\n",
+    "from pathlib import Path\n",
+    "\n",
+    "from cool_seq_tool.schemas import Assembly, CoordinateType\n",
+    "\n",
+    "from fusor.harvester import StarFusionHarvester\n",
+    "\n",
+    "path = Path(\"../../../tests/fixtures/star-fusion.fusion_predictions.abridged.tsv\")\n",
+    "harvester = StarFusionHarvester()\n",
+    "fusions_list = harvester.load_records(path)\n",
+    "assayed_fusion = await translator.from_star_fusion(\n",
+    "        fusions_list[0],\n",
+    "        CoordinateType.RESIDUE.value,\n",
+    "        Assembly.GRCH38.value\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c4a0b16d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load in accepted fusion variants\n",
+    "variants = civic.get_all_fusion_variants(include_status=\"accepted\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "483fb8cc",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING:cool_seq_tool.mappers.exon_genomic_coords:48406078 on NC_000023.11 does not occur within the exons for NM_005636.4\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Generate CategoricalFusion objects from CIViC\n",
+    "from fusor.harvester import CIVICHarvester\n",
+    "\n",
+    "harvester = CIVICHarvester(fusions_list=variants)\n",
+    "fusions_list = harvester.load_records()\n",
+    "\n",
+    "categorical_fusions = []\n",
+    "for fusion in fusions_list:\n",
+    "    if \"?\" in fusion.vicc_compliant_name:\n",
+    "        continue\n",
+    "    cex = await translator.from_civic(civic=fusion)\n",
+    "    categorical_fusions.append(cex)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "52333fb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define evidence matching method\n",
+    "from fusor.models import (\n",
+    "    AssayedFusion,\n",
+    "    CategoricalFusion,\n",
+    "    GeneElement,\n",
+    "    MultiplePossibleGenesElement,\n",
+    "    TranscriptSegmentElement,\n",
+    "    UnknownGeneElement,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "def compare_structure(assayed_element: TranscriptSegmentElement | UnknownGeneElement | GeneElement, categorical_element: TranscriptSegmentElement | MultiplePossibleGenesElement | GeneElement, is_five_prime_partner: bool) -> int:\n",
+    "    \"\"\"Compare transcript segments for an assayed and categorical fusions\n",
+    "    :param assayed_transcript: The assayed fusion transcript or unknown gene element or gene element\n",
+    "    :param categorical_transcript: The categorical fusion transcript or mulitple possible genes element\n",
+    "    :param is_five_prime_partner: If the 5' fusion partner is being compared\n",
+    "    :return A score indiciating the degree of match\n",
+    "    \"\"\"\n",
+    "    match_score = 0\n",
+    "    # If the assayed partner is unknown and the categorical partner can be any symbol, return match score of 1\n",
+    "    if isinstance(assayed_element, UnknownGeneElement) or isinstance(categorical_element, MultiplePossibleGenesElement):\n",
+    "        return 1\n",
+    "\n",
+    "    # Compare gene partners first\n",
+    "    if assayed_element.gene == categorical_element.gene:\n",
+    "        match_score += 1\n",
+    "\n",
+    "    # Then compare transcript partners if transcript data exists\n",
+    "    if isinstance(assayed_element, TranscriptSegmentElement) and isinstance(categorical_element, TranscriptSegmentElement):\n",
+    "        if (\n",
+    "            assayed_element.transcript\n",
+    "            and categorical_element.transcript\n",
+    "            and assayed_element.transcript == categorical_element.transcript\n",
+    "        ):\n",
+    "            match_score += 1\n",
+    "\n",
+    "        if is_five_prime_partner:\n",
+    "            fields_to_compare = [\"exonEnd\", \"exonEndOffset\", \"elementGenomicEnd\"]\n",
+    "        else:\n",
+    "            fields_to_compare = [\"exonStart\", \"exonStartOffset\", \"elementGenomicStart\"]\n",
+    "\n",
+    "        for field in fields_to_compare:\n",
+    "            if getattr(assayed_element, field) == getattr(categorical_element, field):\n",
+    "                match_score += 1\n",
+    "\n",
+    "    return match_score\n",
+    "\n",
+    "def compare_fusion(assayed_fusion: AssayedFusion, categorical_fusion: CategoricalFusion) -> int:\n",
+    "    \"\"\"Compare assayed and categorical fusions\n",
+    "    :param assayed_fusion: AssayedFusion object\n",
+    "    :param categorical_fusion: CategoricalFusion object\n",
+    "    :return Match score\n",
+    "    \"\"\"\n",
+    "    assayed_transcript_segments = assayed_fusion.structure\n",
+    "    categorical_transcript_segments = categorical_fusion.structure\n",
+    "    match_score = 0\n",
+    "\n",
+    "    # Check for linker elements\n",
+    "    if (\n",
+    "        len(assayed_transcript_segments) == len(categorical_transcript_segments) == 3\n",
+    "        and assayed_transcript_segments[1] == categorical_transcript_segments[1]\n",
+    "        ):\n",
+    "        match_score += 1\n",
+    "\n",
+    "    # Compare other structural elements\n",
+    "    else:\n",
+    "        match_score += compare_structure(assayed_transcript_segments[0], categorical_transcript_segments[0], True)\n",
+    "        match_score += compare_structure(assayed_transcript_segments[1], categorical_transcript_segments[1], False)\n",
+    "    return match_score\n",
+    "\n",
+    "def match_fusion(assayed_fusion: AssayedFusion, categorical_fusions: list[CategoricalFusion]) -> tuple[list[CategoricalFusion], int]:\n",
+    "    \"\"\"Return best matching fusion\n",
+    "    :param assayed_fusion: The assayed fusion object\n",
+    "    :param categorical_fusions: A list of categorical fusion objects\n",
+    "    :return A list with best matching categorical fusion objects and its corresponding score\n",
+    "    \"\"\"\n",
+    "    fusions_to_return = []\n",
+    "    score_to_return = 0\n",
+    "    for categorical_fusion in categorical_fusions:\n",
+    "        match_score = compare_fusion(assayed_fusion, categorical_fusion)\n",
+    "        if match_score > score_to_return:\n",
+    "            fusions_to_return = [categorical_fusion]\n",
+    "            score_to_return = match_score\n",
+    "        elif match_score == score_to_return:\n",
+    "            fusions_to_return.append(categorical_fusion)\n",
+    "    return (fusions_to_return, score_to_return)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "9b2d9760",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "([CategoricalFusion(type=<FUSORTypes.CATEGORICAL_FUSION: 'CategoricalFusion'>, regulatoryElement=None, structure=[TranscriptSegmentElement(type=<FUSORTypes.TRANSCRIPT_SEGMENT_ELEMENT: 'TranscriptSegmentElement'>, transcript='refseq:NM_004521.3', exonStart=None, exonStartOffset=None, exonEnd=24, exonEndOffset=0, gene=MappableConcept(id=None, extensions=None, conceptType='Gene', name='KIF5B', primaryCoding=Coding(id='hgnc:6324', extensions=None, name=None, system='https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/', systemVersion=None, code=code(root='HGNC:6324'), iris=None), mappings=None), elementGenomicStart=None, elementGenomicEnd=SequenceLocation(id='ga4gh:SL.nk8wv9yKzCFQ0n7Ph2JnJhOkf2Fzfh_U', type='SequenceLocation', name=None, description=None, aliases=None, extensions=None, digest='nk8wv9yKzCFQ0n7Ph2JnJhOkf2Fzfh_U', sequenceReference=SequenceReference(id='refseq:NC_000010.11', type='SequenceReference', name=None, description=None, aliases=None, extensions=None, refgetAccession='SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB', residueAlphabet=None, circular=None, sequence=None, moleculeType=None), start=32017142, end=None, sequence=None), coverage=None, anchoredReads=None), TranscriptSegmentElement(type=<FUSORTypes.TRANSCRIPT_SEGMENT_ELEMENT: 'TranscriptSegmentElement'>, transcript='refseq:NM_020975.6', exonStart=11, exonStartOffset=0, exonEnd=None, exonEndOffset=None, gene=MappableConcept(id=None, extensions=None, conceptType='Gene', name='RET', primaryCoding=Coding(id='hgnc:9967', extensions=None, name=None, system='https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/', systemVersion=None, code=code(root='HGNC:9967'), iris=None), mappings=None), elementGenomicStart=SequenceLocation(id='ga4gh:SL.0VPUcnlmNOg_8HrscpHFr3HD2BNhHU3B', type='SequenceLocation', name=None, description=None, aliases=None, extensions=None, digest='0VPUcnlmNOg_8HrscpHFr3HD2BNhHU3B', sequenceReference=SequenceReference(id='refseq:NC_000010.11', type='SequenceReference', name=None, description=None, aliases=None, extensions=None, refgetAccession='SQ.ss8r_wB0-b9r44TQTMmVTI92884QvBiB', residueAlphabet=None, circular=None, sequence=None, moleculeType=None), start=43114479, end=None, sequence=None), elementGenomicEnd=None, coverage=None, anchoredReads=None)], readingFramePreserved=None, criticalFunctionalDomains=None, civicMolecularProfiles=[<CIViC molecular_profile 269>])],\n",
+       " 10)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Generate list of matches, report match score\n",
+    "matches = match_fusion(assayed_fusion, categorical_fusions)\n",
+    "matches"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86954c92",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'_assertions': [],\n",
+       " '_therapies': [<CIViC therapy 117>],\n",
+       " '_phenotypes': [],\n",
+       " '_incomplete': {'therapies'},\n",
+       " '_partial': False,\n",
+       " 'type': 'evidence',\n",
+       " 'id': 698,\n",
+       " 'variant_origin': 'SOMATIC',\n",
+       " 'therapy_interaction_type': None,\n",
+       " 'therapy_ids': [117],\n",
+       " 'status': 'accepted',\n",
+       " 'source_id': 378,\n",
+       " 'significance': 'SENSITIVITYRESPONSE',\n",
+       " 'rating': 2,\n",
+       " 'phenotype_ids': [],\n",
+       " 'name': 'EID698',\n",
+       " 'molecular_profile_id': 269,\n",
+       " 'evidence_type': 'PREDICTIVE',\n",
+       " 'evidence_level': 'C',\n",
+       " 'evidence_direction': 'SUPPORTS',\n",
+       " 'disease_id': 30,\n",
+       " 'description': 'A case study of a patient with EGFR, KRAS, BRAF, HER2, ALK, ROS1 and MET negative adenocarcinoma of the lung. FISH analysis revealed a KIF5B-RET fusion. The RET inhibitor Vandetanib led to remission in the patient.',\n",
+       " 'assertion_ids': [],\n",
+       " '_include_status': ['accepted', 'submitted', 'rejected']}"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# View evidence item linked to matched categorical fusion\n",
+    "matches[0][0].civicMolecularProfiles[0].evidence_items[0].__dict__"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds an analysis notebook for demonstrating evidence matching between a KIF5B::RET fusion from an assay and categorical fusions from the CIViC knowledgebase.

Fusions are compared at the following attributes at the transcript level:
- Gene Element
- Transcript accession
- Exon number
- Exon offset
- SequenceLocation describing breakpoint

Linker sequences are also compared if present. With five possible points for each transcript (x2 transcript segments), and one point for the linker sequence, the highest possible match score is 11 points.

The matching algorithm outputs a list of the highest matching CategoricalFusion objects along with their match score. Evidence and assertion statements can than be accessed from the matching CategoricalFusion objects.