### PR TITLE
test: Adding remaining assertions to MOA fusion matching test fixture

### DIFF
--- a/tests/fusion_matching_test_cases.yaml
+++ b/tests/fusion_matching_test_cases.yaml
@@ -189,3 +189,115 @@ tests:
             - gene:
                 name: "ABL1"
         score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2
+      - fields:
+          type: "CategoricalFusion"
+          structure:
+            - gene:
+                name: "BCR"
+            - gene:
+                name: "ABL1"
+        score: 2


### PR DESCRIPTION
With the use of MOA data processed by wags-tails, there are 14 additional BCR::ABL1 categorical fusion objects generated that had not been included in `fusion_matching_test_cases.yaml`. This PR adds those test cases to the yaml file to ensure complete coverage in the test.