### PR TITLE
fix: Use Assembly value as identifier, not name

### DIFF
--- a/src/fusor/translator.py
+++ b/src/fusor/translator.py
@@ -199,7 +199,7 @@ class Translator(ABC):
         )
         return False
 
-    def _get_genomic_ac(self, chrom: str, build: Assembly | str) -> str:
+    def _get_genomic_ac(self, chrom: str, build: Assembly) -> str:
         """Return a RefSeq genomic accession given a chromosome and a reference build
 
         :param chrom: A chromosome number
@@ -208,9 +208,8 @@ class Translator(ABC):
         :raise ValueError: if unable to retrieve genomic accession
         """
         sr = self.fusor.cool_seq_tool.seqrepo_access
-        build_id = build.value if isinstance(build, Assembly) else build
         alias_list, errors = sr.translate_identifier(
-            f"{build_id}:{chrom}", target_namespaces="refseq"
+            f"{build.value}:{chrom}", target_namespaces="refseq"
         )
         if errors:
             statement = f"Genomic accession for {chrom} could not be retrieved"
@@ -1057,10 +1056,10 @@ class CIVICTranslator(Translator):
             isinstance(civic.five_prime_end_exon_coords, ExonCoordinate)
             and civic.five_prime_end_exon_coords.chromosome
         ):  # Process for cases where exon data is available for 5' transcript
-            rb = (
-                Assembly.GRCH37.value
+            rb: Assembly = (
+                Assembly.GRCH37
                 if civic.five_prime_end_exon_coords.reference_build == "GRCH37"
-                else Assembly.GRCH38.value
+                else Assembly.GRCH38
             )
             tr_5prime = await self.fusor.transcript_segment_element(
                 tx_to_genomic_coords=False,
@@ -1081,10 +1080,10 @@ class CIVICTranslator(Translator):
             isinstance(civic.three_prime_start_exon_coords, ExonCoordinate)
             and civic.three_prime_start_exon_coords.chromosome
         ):  # Process for case where exon data is available for 3' transcript
-            rb = (
-                Assembly.GRCH37.value
+            rb: Assembly = (
+                Assembly.GRCH37
                 if civic.three_prime_start_exon_coords.reference_build == "GRCH37"
-                else Assembly.GRCH38.value
+                else Assembly.GRCH38
             )
             tr_3prime = await self.fusor.transcript_segment_element(
                 tx_to_genomic_coords=False,

--- a/tests/test_fusion_matching.py
+++ b/tests/test_fusion_matching.py
@@ -40,14 +40,12 @@ async def test_fusion_matching(
 
     # Load STAR-Fusion records
     path = Path(fixture_data_dir / "star_fusion_test.tsv")
-    harvester = StarFusionHarvester(
-        fusor=fusor_instance, assembly=Assembly.GRCH38.value
-    )
+    harvester = StarFusionHarvester(fusor=fusor_instance, assembly=Assembly.GRCH38)
     fusions_list = await harvester.load_records(path)
 
     # Load in Arriba records
     path = Path(fixture_data_dir / "fusions_arriba_test.tsv")
-    harvester = ArribaHarvester(fusor=fusor_instance, assembly=Assembly.GRCH37.value)
+    harvester = ArribaHarvester(fusor=fusor_instance, assembly=Assembly.GRCH37)
     arriba_fusion = await harvester.load_records(path)
     fusions_list.append(arriba_fusion[0])
 

--- a/tests/test_harvesters.py
+++ b/tests/test_harvesters.py
@@ -22,7 +22,7 @@ from fusor.harvester import (
 async def test_get_jaffa_records(fixture_data_dir, fusor_instance):
     """Test that JAFFAHarvester works correctly"""
     path = Path(fixture_data_dir / "jaffa_results_test.csv")
-    harvester = JAFFAHarvester(fusor_instance, assembly=Assembly.GRCH38.value)
+    harvester = JAFFAHarvester(fusor_instance, assembly=Assembly.GRCH38)
     records = await harvester.load_records(path)
     assert len(records) == 2
 
@@ -34,7 +34,7 @@ async def test_get_jaffa_records(fixture_data_dir, fusor_instance):
 async def test_get_star_fusion_records(fixture_data_dir, fusor_instance):
     """Test that STARFusionHarvester works correctly"""
     path = Path(fixture_data_dir / "star_fusion_test.tsv")
-    harvester = StarFusionHarvester(fusor_instance, assembly=Assembly.GRCH38.value)
+    harvester = StarFusionHarvester(fusor_instance, assembly=Assembly.GRCH38)
     records = await harvester.load_records(path)
     assert len(records) == 3
 
@@ -46,7 +46,7 @@ async def test_get_star_fusion_records(fixture_data_dir, fusor_instance):
 async def test_get_fusion_catcher_records(fixture_data_dir, fusor_instance):
     """Test that FusionCatcherHarvester works correctly"""
     path = Path(fixture_data_dir / "fusion_catcher_test.txt")
-    harvester = FusionCatcherHarvester(fusor_instance, assembly=Assembly.GRCH38.value)
+    harvester = FusionCatcherHarvester(fusor_instance, assembly=Assembly.GRCH38)
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 3
 
@@ -58,7 +58,7 @@ async def test_get_fusion_catcher_records(fixture_data_dir, fusor_instance):
 async def test_get_arriba_records(fixture_data_dir, fusor_instance):
     """Test that ArribaHarvester works correctly"""
     path = Path(fixture_data_dir / "fusions_arriba_test.tsv")
-    harvester = ArribaHarvester(fusor_instance, assembly=Assembly.GRCH37.value)
+    harvester = ArribaHarvester(fusor_instance, assembly=Assembly.GRCH37)
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
 
@@ -70,7 +70,7 @@ async def test_get_arriba_records(fixture_data_dir, fusor_instance):
 async def test_get_cicero_records(fixture_data_dir, fusor_instance):
     """Test that CiceroHarvester works correctly"""
     path = Path(fixture_data_dir / "annotated.fusion.txt")
-    harvester = CiceroHarvester(fusor_instance, assembly=Assembly.GRCH38.value)
+    harvester = CiceroHarvester(fusor_instance, assembly=Assembly.GRCH38)
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
 
@@ -82,7 +82,7 @@ async def test_get_cicero_records(fixture_data_dir, fusor_instance):
 async def test_get_enfusion_records(fixture_data_dir, fusor_instance):
     """Test that EnFusionHarvester works correctly"""
     path = Path(fixture_data_dir / "enfusion_test.csv")
-    harvester = EnFusionHarvester(fusor_instance, assembly=Assembly.GRCH38.value)
+    harvester = EnFusionHarvester(fusor_instance, assembly=Assembly.GRCH38)
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
 
@@ -94,7 +94,7 @@ async def test_get_enfusion_records(fixture_data_dir, fusor_instance):
 async def test_get_genie_records(fixture_data_dir, fusor_instance):
     """Test that GenieHarvester works correctly"""
     path = Path(fixture_data_dir / "genie_test.txt")
-    harvester = GenieHarvester(fusor_instance, assembly=Assembly.GRCH38.value)
+    harvester = GenieHarvester(fusor_instance, assembly=Assembly.GRCH38)
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
 

--- a/tests/test_translators.py
+++ b/tests/test_translators.py
@@ -377,8 +377,8 @@ async def test_jaffa(
 
     jaffa_fusor = await translator.translate(
         jaffa,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example = fusion_data_example(
         readData=ReadData(
@@ -395,8 +395,8 @@ async def test_jaffa(
 
     jaffa_fusor_nonexonic = await translator.translate(
         jaffa,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example_nonexonic = fusion_data_example_nonexonic(
         readData=ReadData(
@@ -413,13 +413,13 @@ async def test_jaffa(
     # Test unknown partner
     jaffa.fusion_genes = "NA:PDGFRB"
     jaffa_fusor_unknown = await translator.translate(
-        jaffa, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        jaffa, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert jaffa_fusor_unknown.structure[0] == UnknownGeneElement()
     assert jaffa_fusor_unknown.viccNomenclature == "?::NM_002609.4(PDGFRB):e.11-559"
     jaffa.fusion_genes = "TPM3:NA"
     jaffa_fusor_unknown = await translator.translate(
-        jaffa, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        jaffa, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert jaffa_fusor_unknown.structure[1] == UnknownGeneElement()
     assert jaffa_fusor_unknown.viccNomenclature == "NM_152263.4(TPM3):e.4+5::?"
@@ -444,8 +444,8 @@ async def test_star_fusion(
 
     star_fusion_fusor = await translator.translate(
         star_fusion,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example = fusion_data_example(
         readData=ReadData(
@@ -462,8 +462,8 @@ async def test_star_fusion(
 
     star_fusion_fusor_nonexonic = await translator.translate(
         star_fusion,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example_nonexonic = fusion_data_example_nonexonic(
         readData=ReadData(
@@ -485,8 +485,8 @@ async def test_star_fusion(
     star_fusion.left_gene = "NA"
     star_fusion_fusor_unknown = await translator.translate(
         star_fusion,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     assert star_fusion_fusor_unknown.structure[0] == UnknownGeneElement()
     assert (
@@ -496,8 +496,8 @@ async def test_star_fusion(
     star_fusion.right_gene = "NA"
     star_fusion_fusor_unknown = await translator.translate(
         star_fusion,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     assert star_fusion_fusor_unknown.structure[1] == UnknownGeneElement()
     assert star_fusion_fusor_unknown.viccNomenclature == "NM_152263.4(TPM3):e.4+4::?"
@@ -523,8 +523,8 @@ async def test_fusion_catcher(
 
     fusion_catcher_fusor = await translator.translate(
         fusion_catcher,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example = fusion_data_example(
         readData=ReadData(
@@ -545,8 +545,8 @@ async def test_fusion_catcher(
 
     fusion_catcher_fusor_nonexonic = await translator.translate(
         fusion_catcher,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example_nonexonic = fusion_data_example_nonexonic(
         readData=ReadData(
@@ -571,7 +571,7 @@ async def test_fusion_catcher(
     # Test unknown partners
     fusion_catcher.five_prime_partner = "NA"
     fusion_catcher_fusor_unknown = await translator.translate(
-        fusion_catcher, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        fusion_catcher, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert fusion_catcher_fusor_unknown.structure[0] == UnknownGeneElement()
     assert (
@@ -581,7 +581,7 @@ async def test_fusion_catcher(
     fusion_catcher.five_prime_partner = "TPM3"
     fusion_catcher.three_prime_partner = "NA"
     fusion_catcher_fusor_unknown = await translator.translate(
-        fusion_catcher, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        fusion_catcher, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert fusion_catcher_fusor_unknown.structure[1] == UnknownGeneElement()
     assert fusion_catcher_fusor_unknown.viccNomenclature == "NM_152263.4(TPM3):e.4+5::?"
@@ -608,7 +608,7 @@ async def test_fusion_map(
         }
     )
     fusion_map_fusor = await translator.translate(
-        fusion_map_data, CoordinateType.INTER_RESIDUE.value, Assembly.GRCH38.value
+        fusion_map_data, CoordinateType.INTER_RESIDUE, Assembly.GRCH38
     )
     assert fusion_map_fusor.structure == fusion_data_example().structure
 
@@ -627,7 +627,7 @@ async def test_fusion_map(
         }
     )
     fusion_map_fusor_nonexonic = await translator.translate(
-        fusion_map_data_nonexonic, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        fusion_map_data_nonexonic, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert (
         fusion_map_fusor_nonexonic.structure
@@ -664,8 +664,8 @@ async def test_arriba(
 
     arriba_fusor = await translator.translate(
         arriba,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example = fusion_data_example(
         readData=ReadData(spanning=SpanningReads(spanningReads=30)),
@@ -686,8 +686,8 @@ async def test_arriba(
 
     arriba_fusor_nonexonic = await translator.translate(
         arriba,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example_nonexonic = fusion_data_example_nonexonic(
         readData=ReadData(spanning=SpanningReads(spanningReads=30)),
@@ -713,7 +713,7 @@ async def test_arriba(
     arriba_linker = arriba.model_copy(deep=True)
     arriba_linker.fusion_transcript = "ATAGAT|atatacgat|TATGAT"
     arriba_fusor_linker = await translator.translate(
-        arriba_linker, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        arriba_linker, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     linker_element = arriba_fusor_linker.structure[1]
     assert linker_element
@@ -726,14 +726,14 @@ async def test_arriba(
     # Test unknown partners
     arriba.gene1 = "NA"
     arriba_fusor_unknown = await translator.translate(
-        arriba, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        arriba, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert arriba_fusor_unknown.structure[0] == UnknownGeneElement()
     assert arriba_fusor_unknown.viccNomenclature == "?::NM_002609.4(PDGFRB):e.11-559"
     arriba.gene1 = "TPM3"
     arriba.gene2 = "NA"
     arriba_fusor_unknown = await translator.translate(
-        arriba, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        arriba, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert arriba_fusor_unknown.structure[1] == UnknownGeneElement()
     assert arriba_fusor_unknown.viccNomenclature == "NM_152263.4(TPM3):e.4+5::?"
@@ -764,8 +764,8 @@ async def test_cicero(
 
     cicero_fusor = await translator.translate(
         cicero,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example = fusion_data_example(
         contig=ContigSequence(contig=cicero.contig)
@@ -785,8 +785,8 @@ async def test_cicero(
 
     cicero_fusor_nonexonic = await translator.translate(
         cicero,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     fusion_data_example_nonexonic = fusion_data_example_nonexonic(
         contig=ContigSequence(contig=cicero.contig)
@@ -812,8 +812,8 @@ async def test_cicero(
 
     non_confident_bio = await translator.translate(
         cicero,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     assert (
         non_confident_bio
@@ -825,8 +825,8 @@ async def test_cicero(
 
     multiple_genes_fusion_partner = await translator.translate(
         cicero,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     assert (
         multiple_genes_fusion_partner
@@ -838,14 +838,14 @@ async def test_cicero(
     cicero.gene_5prime = "NA"
     cicero.gene_3prime = "PDGFRB"
     cicero_fusor_unknown = await translator.translate(
-        cicero, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        cicero, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert cicero_fusor_unknown.viccNomenclature == "?::NM_002609.4(PDGFRB):e.11-559"
     assert cicero_fusor_unknown.structure[0] == UnknownGeneElement()
     cicero.gene_5prime = "TPM3"
     cicero.gene_3prime = "NA"
     cicero_fusor_unknown = await translator.translate(
-        cicero, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        cicero, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert cicero_fusor_unknown.structure[1] == UnknownGeneElement()
     assert cicero_fusor_unknown.viccNomenclature == "NM_152263.4(TPM3):e.4+5::?"
@@ -869,8 +869,8 @@ async def test_enfusion(
 
     enfusion_fusor = await translator.translate(
         enfusion,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     assert enfusion_fusor.structure == fusion_data_example().structure
     assert enfusion_fusor.viccNomenclature == fusion_data_example().viccNomenclature
@@ -881,8 +881,8 @@ async def test_enfusion(
 
     enfusion_fusor_nonexonic = await translator.translate(
         enfusion,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     assert (
         enfusion_fusor_nonexonic.structure == fusion_data_example_nonexonic().structure
@@ -895,14 +895,14 @@ async def test_enfusion(
     # Test unknown partner
     enfusion.gene_5prime = "NA"
     enfusion_fusor_unknown = await translator.translate(
-        enfusion, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        enfusion, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert enfusion_fusor_unknown.structure[0] == UnknownGeneElement()
     assert enfusion_fusor_unknown.viccNomenclature == "?::NM_002609.4(PDGFRB):e.11-559"
     enfusion.gene_5prime = "TPM3"
     enfusion.gene_3prime = "NA"
     enfusion_fusor_unknown = await translator.translate(
-        enfusion, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        enfusion, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert enfusion_fusor_unknown.structure[1] == UnknownGeneElement()
     assert enfusion_fusor_unknown.viccNomenclature == "NM_152263.4(TPM3):e.4+5::?"
@@ -928,8 +928,8 @@ async def test_genie(
 
     genie_fusor = await translator.translate(
         genie,
-        CoordinateType.INTER_RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.INTER_RESIDUE,
+        Assembly.GRCH38,
     )
     assert genie_fusor.structure == fusion_data_example().structure
     assert genie_fusor.viccNomenclature == fusion_data_example().viccNomenclature
@@ -940,8 +940,8 @@ async def test_genie(
 
     genie_fusor_nonexonic = await translator.translate(
         genie,
-        CoordinateType.RESIDUE.value,
-        Assembly.GRCH38.value,
+        CoordinateType.RESIDUE,
+        Assembly.GRCH38,
     )
     assert genie_fusor_nonexonic.structure == fusion_data_example_nonexonic().structure
     assert (
@@ -952,14 +952,14 @@ async def test_genie(
     # Test unknown partner
     genie.site1_hugo = "NA"
     genie_fusor_unknown = await translator.translate(
-        genie, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        genie, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert genie_fusor_unknown.structure[0] == UnknownGeneElement()
     assert genie_fusor_unknown.viccNomenclature == "?::NM_002609.4(PDGFRB):e.11-559"
     genie.site1_hugo = "TPM3"
     genie.site2_hugo = "NA"
     genie_fusor_unknown = await translator.translate(
-        genie, CoordinateType.RESIDUE.value, Assembly.GRCH38.value
+        genie, CoordinateType.RESIDUE, Assembly.GRCH38
     )
     assert genie_fusor_unknown.structure[1] == UnknownGeneElement()
     assert genie_fusor_unknown.viccNomenclature == "NM_152263.4(TPM3):e.4+5::?"


### PR DESCRIPTION
I noticed an issue in FUSOR where the translator was using the incorrect genomic version.

```
SeqRepo unable to get translated identifiers for Assembly.GRCH38:chr1
Genomic accession for chr1 could not be retrieved
ValueError encountered while loading records from jaffa_sample.txt
Traceback (most recent call last):
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/harvester.py", line 116, in load_records
    translated_fusion = await self.translator.translate(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        fusion, self.coordinate_type, self.assembly
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/translator.py", line 319, in translate
    genomic_ac=self._get_genomic_ac(jaffa.chrom1, rb),
               ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/translator.py", line 217, in _get_genomic_ac
    raise ValueError
ValueError
1 fusion(s) were dropped during translation
```

You can see in the first line of the error, it's attempting to query seqrepo using `Assembly.GRCH38:chr1`, rather than `GRCh38:chr1`.

The [translator formats that value](https://github.com/cancervariants/fusor/blob/main/src/fusor/translator.py#L212) using a `str` call on the Assembly (implicit via an f-string). Because this value is an enum, the result is the enum's key. The `value` field has the correctly formatted string:

```
>>> a = Assembly.GRCH38
>>> str(a)
'Assembly.GRCH38'
>>> a.value
'GRCh38'
```

I modified the translator to call `value` on the Assembly. I also fixed the unit tests which were passing in a `str` value as build.

<details>
<summary>Output before:</summary>

```
> ./test-fusor.py jaffa                                                                                                                
SeqRepo unable to get translated identifiers for Assembly.GRCH38:chr1
Genomic accession for chr1 could not be retrieved
ValueError encountered while loading records from jaffa_sample.txt
Traceback (most recent call last):
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/harvester.py", line 116, in load_records
    translated_fusion = await self.translator.translate(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        fusion, self.coordinate_type, self.assembly
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/translator.py", line 319, in translate
    genomic_ac=self._get_genomic_ac(jaffa.chrom1, rb),
               ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/translator.py", line 217, in _get_genomic_ac
    raise ValueError
ValueError
1 fusion(s) were dropped during translation
```
</details>

<details>
<summary>Output after:</summary>

```
>  ./test-fusor.py jaffa                                                                                                                
{"type":"AssayedFusion","regulatoryElement":null,"structure":[{"type":"TranscriptSegmentElement","transcript":"refseq:NM_170707.4","strand":1,"exonStart":null,"exonStartOffset":null,"exonEnd":2,"exonEndOffset":0,"gene":{"id":null,"extensions":null,"conceptType":"Gene","name":"LMNA","primaryCoding":{"id":"hgnc:6636","extensions":null,"name":null,"system":"https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/","systemVersion":null,"code":"HGNC:6636","iris":null},"mappings":null},"elementGenomicStart":null,"elementGenomicEnd":{"id":"ga4gh:SL.99a9r3W9FBpCbCoMKpypLNDzjICf9k6X","type":"SequenceLocation","name":null,"description":null,"aliases":null,"extensions":null,"digest":"99a9r3W9FBpCbCoMKpypLNDzjICf9k6X","sequenceReference":{"id":"refseq:NC_000001.11","type":"SequenceReference","name":null,"description":null,"aliases":null,"extensions":null,"refgetAccession":"SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO","residueAlphabet":null,"circular":null,"sequence":null,"moleculeType":null},"start":null,"end":156130773,"sequence":null},"coverage":null,"anchoredReads":null},{"type":"TranscriptSegmentElement","transcript":"refseq:NM_002529.4","strand":1,"exonStart":11,"exonStartOffset":0,"exonEnd":null,"exonEndOffset":null,"gene":{"id":null,"extensions":null,"conceptType":"Gene","name":"NTRK1","primaryCoding":{"id":"hgnc:8031","extensions":null,"name":null,"system":"https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/","systemVersion":null,"code":"HGNC:8031","iris":null},"mappings":null},"elementGenomicStart":{"id":"ga4gh:SL.w6FL8tvp9-KPUBj19HufOFJVmu9CKnyh","type":"SequenceLocation","name":null,"description":null,"aliases":null,"extensions":null,"digest":"w6FL8tvp9-KPUBj19HufOFJVmu9CKnyh","sequenceReference":{"id":"refseq:NC_000001.11","type":"SequenceReference","name":null,"description":null,"aliases":null,"extensions":null,"refgetAccession":"SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO","residueAlphabet":null,"circular":null,"sequence":null,"moleculeType":null},"start":156874905,"end":null,"sequence":null},"elementGenomicEnd":null,"coverage":null,"anchoredReads":null}],"readingFramePreserved":null,"viccNomenclature":"NM_170707.4(LMNA):e.2::NM_002529.4(NTRK1):e.11","causativeEvent":null,"assay":null,"contig":null,"readData":{"type":"ReadData","split":{"type":"SplitReads","splitReads":6},"spanning":{"type":"SpanningReads","spanningReads":3}}}
```
</details>


<details>
<summary>Pytest results</summary>

```
> pytest
========================================================================= test session starts ==========================================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/zxw016/dev/wagner/fusor
configfile: pyproject.toml
testpaths: tests
plugins: anyio-4.9.0, asyncio-1.1.0, cov-6.2.1
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 55 items                                                                                                                                                     

tests/test_fusion_matching.py .                                                                                                                                  [  1%]
tests/test_fusor.py ..........                                                                                                                                   [ 20%]
tests/test_harvesters.py .........                                                                                                                               [ 36%]
tests/test_models.py .....................                                                                                                                       [ 74%]
tests/test_nomenclature.py ..                                                                                                                                    [ 78%]
tests/test_tools.py ..                                                                                                                                           [ 81%]
tests/test_translators.py ..........                                                                                                                             [100%]

============================================================================ tests coverage ============================================================================
___________________________________________________________ coverage: platform darwin, python 3.13.5-final-0 ___________________________________________________________

Name                                Stmts   Miss  Cover   Missing
-----------------------------------------------------------------
src/fusor/__init__.py                   8      2    75%   12-13
src/fusor/config.py                    12      1    92%   25
src/fusor/examples/__init__.py         24      0   100%
src/fusor/exceptions.py                 2      0   100%
src/fusor/fusion_caller_models.py     115      0   100%
src/fusor/fusion_matching.py           98     16    84%   42-43, 45, 66-67, 96, 183, 192, 232-238, 250, 280-281
src/fusor/fusor.py                    203     18    91%   75, 114-115, 123-124, 158-159, 275-280, 294, 463, 503, 512-515, 559
src/fusor/harvester.py                146      6    96%   85-86, 119-120, 292, 318
src/fusor/models.py                   301      7    98%   281-282, 585-586, 606, 685-686
src/fusor/nomenclature.py              94      9    90%   48-49, 55, 58, 115-116, 118-119, 172
src/fusor/tools.py                     42     17    60%   40, 73-92, 106
src/fusor/translator.py               295     44    85%   143, 172-181, 197-200, 215-217, 237, 273-275, 314, 390, 462, 531, 602, 730, 757, 796-829, 857, 920, 997, 1026, 1052
-----------------------------------------------------------------
TOTAL                                1340    120    91%
========================================================================= 55 passed in 50.85s ==========================================================================
</details>