### PR TITLE
fix: Catch errors from create_db when gene normalizer db unavailable

### DIFF
--- a/src/fusor/tools.py
+++ b/src/fusor/tools.py
@@ -74,11 +74,10 @@ async def check_data_resources(
         cool_seq_tool = CoolSeqTool()
     cst_status = await check_cst_status()
 
-    if gene_database is None:
-        gene_database = create_db()
-
     gene_status = False
     try:
+        if gene_database is None:
+            gene_database = create_db()
         if not gene_database.check_schema_initialized():
             _logger.error("Health check failed: gene DB schema uninitialized")
         else:


### PR DESCRIPTION
FUSOR's `fusor.tools.check_data_resources` method crashes if the gene normalizer database isn't available, rather than reporting that it isn't available via `gene_normalizer=False`. This is because the `create_db()` call is outside the exception handling try/catch block.

I fixed this by moving the `create_db()` call into the try/catch block so that the exception would be caught and the status reported as expected.

<details>
<summary>Output before</summary>
Unhandled exception results in no status object being returned:

```
>  ./test-fusor.py check                                                                                                              
Traceback (most recent call last):
  File "/Users/zxw016/dev/wagner/./test-fusor.py", line 150, in <module>
    main()
    ~~~~^^
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/Users/zxw016/dev/wagner/./test-fusor.py", line 129, in check
    status = asyncio.run(check_data_resources())
  File "/Users/zxw016/.pyenv/versions/3.13.5/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/Users/zxw016/.pyenv/versions/3.13.5/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/zxw016/.pyenv/versions/3.13.5/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/tools.py", line 78, in check_data_resources
    gene_database = create_db()
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/gene/database/database.py", line 336, in create_db
    db = PostgresDatabase(endpoint_url)
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/gene/database/postgresql.py", line 78, in __init__
    self.conn = psycopg.connect(self.conninfo)
                ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/psycopg/connection.py", line 125, in connect
    raise type(last_ex)("\n".join(lines)).with_traceback(None)
psycopg.OperationalError: connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "none" does not exist
Multiple connection attempts failed. All failures were:
- host: 'localhost', port: '5432', hostaddr: '::1': connection failed: connection to server at "::1", port 5432 failed: FATAL:  role "none" does not exist
- host: 'localhost', port: '5432', hostaddr: '127.0.0.1': connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "none" does not exist
```
</details>

<details>
<summary>Output after</summary>
Exception is caught, logged, and the status object is returned.

```
>  ./test-fusor.py check                                                                                                              
Encountered error while creating gene DB during resource check
Traceback (most recent call last):
  File "/Users/zxw016/dev/wagner/fusor/src/fusor/tools.py", line 80, in check_data_resources
    gene_database = create_db()
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/gene/database/database.py", line 336, in create_db
    db = PostgresDatabase(endpoint_url)
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/gene/database/postgresql.py", line 78, in __init__
    self.conn = psycopg.connect(self.conninfo)
                ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/zxw016/dev/wagner/.wagner-venv/lib/python3.13/site-packages/psycopg/connection.py", line 125, in connect
    raise type(last_ex)("\n".join(lines)).with_traceback(None)
psycopg.OperationalError: connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "none" does not exist
Multiple connection attempts failed. All failures were:
- host: 'localhost', port: '5432', hostaddr: '::1': connection failed: connection to server at "::1", port 5432 failed: FATAL:  role "none" does not exist
- host: 'localhost', port: '5432', hostaddr: '127.0.0.1': connection failed: connection to server at "127.0.0.1", port 5432 failed: FATAL:  role "none" does not exist
cool-seq-tool          fusor
---------------------  -----------------
✔ uta                  ✔ cool_seq_tool
✔ seqrepo              ✘ gene_normalizer
✔ transcript_mappings
✔ mane_summary
✔ lrg_refseqgene
✔ mane_refseq_genomic
✔ liftover
```
</details>