### PR TITLE
feat: add harvester method to return both translated and untranslated records

### DIFF
--- a/src/fusor/harvester.py
+++ b/src/fusor/harvester.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC
 from itertools import dropwhile
 from pathlib import Path
-from typing import ClassVar, Generic, TextIO, TypeVar
+from typing import ClassVar, Generic, TextIO, TypeVar, Type
 
 from civicpy import civic
 from cool_seq_tool.schemas import Assembly, CoordinateType
@@ -47,8 +47,8 @@ T = TypeVar("T", bound=Translator)
 class FusionCallerHarvester(ABC, Generic[T]):
     """ABC for fusion caller harvesters"""
 
-    fusion_caller: FusionCaller
-    column_rename: dict
+    fusion_caller: Type[FusionCaller]
+    column_rename: ClassVar[dict[str,str]]
     delimiter: str
     translator_class: type[T]
     coordinate_type: CoordinateType

--- a/src/fusor/harvester.py
+++ b/src/fusor/harvester.py
@@ -6,10 +6,11 @@ import logging
 from abc import ABC
 from itertools import dropwhile
 from pathlib import Path
-from typing import ClassVar, Generic, TextIO, TypeVar, Type
+from typing import Any, ClassVar, Generic, TextIO, TypeVar
 
 from civicpy import civic
 from cool_seq_tool.schemas import Assembly, CoordinateType
+from pydantic.dataclasses import dataclass
 from wags_tails import MoaData
 
 from fusor.config import config
@@ -44,11 +45,25 @@ _logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=Translator)
 
 
+@dataclass
+class FusionCallerRecord:
+    """Records a single entry in a fusion caller data table.
+
+    :param source: The untranslated fusion caller row
+    :param annotated: The annotated fusion data
+    :param annotation_errors: Captures any errors that occurred during fusion translation
+    """
+
+    source: dict[str, Any]
+    annotated: AssayedFusion | CategoricalFusion | None
+    annotation_error: str | None
+
+
 class FusionCallerHarvester(ABC, Generic[T]):
     """ABC for fusion caller harvesters"""
 
-    fusion_caller: Type[FusionCaller]
-    column_rename: ClassVar[dict[str,str]]
+    fusion_caller: type[FusionCaller]
+    column_rename: ClassVar[dict[str, str]]
     delimiter: str
     translator_class: type[T]
     coordinate_type: CoordinateType
@@ -73,7 +88,7 @@ class FusionCallerHarvester(ABC, Generic[T]):
     @staticmethod
     def _count_dropped_fusions(
         initial_fusions: list,
-        translated_fusions: list[AssayedFusion | CategoricalFusion],
+        translated_fusions: list,
     ) -> None:
         """Count the number of fusions that were dropped during translation
 
@@ -95,36 +110,69 @@ class FusionCallerHarvester(ABC, Generic[T]):
         :raise ValueError: if the file does not exist at the specified path
         :return: A list of translated fusions, represented as AssayedFusion objects
         """
+        records = await self.load_record_table(fusion_path)
+        fusions = [
+            record.annotated
+            for record in records
+            if isinstance(record.annotated, AssayedFusion)
+        ]
+        self._count_dropped_fusions(records, fusions)
+
+        return fusions
+
+    async def load_record_table(
+        self,
+        fusion_path: Path,
+    ) -> list[FusionCallerRecord]:
+        """Convert rows of fusion caller output to FusionCallerRecord objects.
+
+        Each entry in the returned list includes the raw fusion caller output row, as well as the
+        annotated fusion model. Any errors encountered when annotating fusions are captured and returned per fusion.
+
+        :param fusion_path: The path to the fusions file
+        :raise ValueError: if the file does not exist at the specified path
+        :return: A list of fusion caller records
+        """
         if not fusion_path.exists():
-            statement = f"{fusion_path!s} does not exist"
-            raise ValueError(statement)
-        fusions_list = []
+            msg = f"{fusion_path!s} does not exist"
+            raise ValueError(msg)
+
         fields_to_keep = self.fusion_caller.__annotations__
         reader = self._get_records(fusion_path.open())
+        records: list[FusionCallerRecord] = []
 
         for row in reader:
+            raw_row = {}
             filtered_row = {}
             for key, value in row.items():
                 renamed_key = self.column_rename.get(key, key)
+                raw_row[renamed_key] = value
                 if renamed_key in fields_to_keep:
                     filtered_row[renamed_key] = value
-            fusions_list.append(self.fusion_caller(**filtered_row))
 
-        translated_fusions = []
-        for fusion in fusions_list:
+            fusion = self.fusion_caller(**filtered_row)
+
+            error: str | None = None
+            translated_fusion: AssayedFusion | CategoricalFusion | None = None
             try:
                 translated_fusion = await self.translator.translate(
                     fusion, self.coordinate_type, self.assembly
                 )
-            except ValueError:
+            except Exception as exc:
                 _logger.exception(
-                    "ValueError encountered while loading records from %s", fusion_path
+                    "Error encountered while loading records from %s", fusion_path
                 )
-            else:
-                translated_fusions.append(translated_fusion)
-        self._count_dropped_fusions(fusions_list, translated_fusions)
+                error = str(exc)
 
-        return translated_fusions
+            records.append(
+                FusionCallerRecord(
+                    source=raw_row,
+                    annotated=translated_fusion,
+                    annotation_error=error,
+                )
+            )
+
+        return records
 
 
 class JAFFAHarvester(FusionCallerHarvester):

--- a/tests/test_harvesters.py
+++ b/tests/test_harvesters.py
@@ -26,6 +26,9 @@ async def test_get_jaffa_records(fixture_data_dir, fusor_instance):
     records = await harvester.load_records(path)
     assert len(records) == 2
 
+    records = await harvester.load_record_table(path)
+    assert len(records) == 2
+
     path = Path(fixture_data_dir / "jaffa_resultss_test.csv")
     with pytest.raises(ValueError, match=f"{path} does not exist"):
         assert await harvester.load_records(path)
@@ -36,6 +39,9 @@ async def test_get_star_fusion_records(fixture_data_dir, fusor_instance):
     path = Path(fixture_data_dir / "star_fusion_test.tsv")
     harvester = StarFusionHarvester(fusor_instance, assembly=Assembly.GRCH38)
     records = await harvester.load_records(path)
+    assert len(records) == 3
+
+    records = await harvester.load_record_table(path)
     assert len(records) == 3
 
     path = Path(fixture_data_dir / "star_fusion_test.tsvs")
@@ -50,6 +56,9 @@ async def test_get_fusion_catcher_records(fixture_data_dir, fusor_instance):
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 3
 
+    records = await harvester.load_record_table(path)
+    assert len(records) == 3
+
     path = Path(fixture_data_dir / "fusionn_catcher.txts")
     with pytest.raises(ValueError, match=f"{path} does not exist"):
         assert await harvester.load_records(path)
@@ -61,6 +70,9 @@ async def test_get_arriba_records(fixture_data_dir, fusor_instance):
     harvester = ArribaHarvester(fusor_instance, assembly=Assembly.GRCH37)
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
+
+    records = await harvester.load_record_table(path)
+    assert len(records) == 1
 
     path = Path(fixture_data_dir / "fusionss_arriba_test.tsv")
     with pytest.raises(ValueError, match=f"{path} does not exist"):
@@ -74,6 +86,9 @@ async def test_get_cicero_records(fixture_data_dir, fusor_instance):
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
 
+    records = await harvester.load_record_table(path)
+    assert len(records) == 1
+
     path = Path(fixture_data_dir / "annnotated.fusion.txt")
     with pytest.raises(ValueError, match=f"{path} does not exist"):
         assert await harvester.load_records(path)
@@ -86,6 +101,9 @@ async def test_get_enfusion_records(fixture_data_dir, fusor_instance):
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
 
+    records = await harvester.load_record_table(path)
+    assert len(records) == 1
+
     path = Path(fixture_data_dir / "enfusions_test.csv")
     with pytest.raises(ValueError, match=f"{path} does not exist"):
         assert await harvester.load_records(path)
@@ -97,6 +115,9 @@ async def test_get_genie_records(fixture_data_dir, fusor_instance):
     harvester = GenieHarvester(fusor_instance, assembly=Assembly.GRCH38)
     fusions_list = await harvester.load_records(path)
     assert len(fusions_list) == 1
+
+    records = await harvester.load_record_table(path)
+    assert len(records) == 1
 
     path = Path(fixture_data_dir / "genie_tests.txt")
     with pytest.raises(ValueError, match=f"{path} does not exist"):


### PR DESCRIPTION
This PR modifies `Harvester` to add a `load_record_table` function which assembles a list of `FusionCallerRecord` objects
which contain the original untranslated fusion caller output (in `source`), the translated FUSOR output (in `annotated`) and any errors that may have happened while translating that call (in `annotation_errors`).

Since this is very similar to the behavior of `load_records`, I refactored `load_records` to call `load_record_table` and then filter down the output to only the annotated records, to preserve the original behavior while minimizing redundant code.

Resolves #302