### PR TITLE
feat!: Remove `cls.__name__` comparator for `AbstractFusion` class

### DIFF
--- a/src/fusor/models.py
+++ b/src/fusor/models.py
@@ -615,9 +615,9 @@ class AbstractFusion(BaseModel, ABC):
     @model_validator(mode="before")
     def enforce_abc(cls, values):
         """Ensure only subclasses can be instantiated."""
-        if cls.__name__ == "AbstractFusion":
+        if cls is AbstractFusion:
             msg = "Cannot instantiate Fusion abstract class"
-            raise ValueError(msg)
+            raise TypeError(msg)
         return values
 
     @model_validator(mode="before")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1033,11 +1033,11 @@ def test_fusion_element_count(
 def test_fusion_abstraction_validator(transcript_segments, linkers):
     """Test that instantiation of abstract fusion fails."""
     # can't create base fusion
-    with pytest.raises(ValidationError) as exc_info:
-        assert AbstractFusion(structure=[transcript_segments[2], linkers[0]])
-    check_validation_error(
-        exc_info, "Value error, Cannot instantiate Fusion abstract class"
-    )
+    with pytest.raises(
+        TypeError,
+        match="Cannot instantiate Fusion abstract class",
+    ):
+        AbstractFusion(structure=[transcript_segments[2], linkers[0]])
 
 
 def test_file_examples():


### PR DESCRIPTION
closes #313 