### PR TITLE
docs: Add fixtures README

### DIFF
--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,4 +1,4 @@
-# Fixtures README
+# Fixtures
 
 There are several files in the `fixtures` directory that were adapted from other repositories to test functionality in FUSOR. The adapted files include:
 


### PR DESCRIPTION
There are several files in the `fixtures` directory that were adapted from other repositories. I have added a README in the `fixtures` directory that lists which files were adapted and links out to their source repositories. 

Note: I did not create an associated issue for this change.