### PR TITLE
build: Update vrs python version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ description = "Computable object representation and validation for gene fusions"
 license = {file = "LICENSE"}
 dependencies = [
     "pydantic ==2.*",
-    "ga4gh.vrs >=2.1.4,<3.0",
+    "ga4gh.vrs >=2.2.0,<3.0",
     "biocommons.seqrepo",
     "gene-normalizer ~=0.10.0",
     "civicpy ~=5.0",


### PR DESCRIPTION
I saw in the vrs-python repo that any 2.x release pre 2.2.0 has been [deprecated](https://github.com/ga4gh/vrs-python/discussions/603). The `pyproject.toml` file had listed the following dependency bounds for vrs-python
```python
 "ga4gh.vrs >=2.1.4,<3.0",
```
I updated this to allow 2.2.0 as the minimum package version.