### PR TITLE
chore: Update zenodo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FUSOR
 [![image](https://img.shields.io/pypi/l/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![image](https://img.shields.io/pypi/pyversions/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![Actions status](https://github.com/cancervariants/fusor/actions/workflows/checks.yaml/badge.svg)](https://github.com/cancervariants/fusor/actions/checks.yaml)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.12708252.svg)](https://doi.org/10.5281/zenodo.12708252)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17343489.svg)](https://zenodo.org/records/17343489)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FUSOR
 [![image](https://img.shields.io/pypi/l/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![image](https://img.shields.io/pypi/pyversions/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![Actions status](https://github.com/cancervariants/fusor/actions/workflows/checks.yaml/badge.svg)](https://github.com/cancervariants/fusor/actions/checks.yaml)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17343489.svg)](https://zenodo.org/records/17343489)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17343489.svg)](https://doi.org/10.5281/zenodo.17343489)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FUSOR
 [![image](https://img.shields.io/pypi/l/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![image](https://img.shields.io/pypi/pyversions/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![Actions status](https://github.com/cancervariants/fusor/actions/workflows/checks.yaml/badge.svg)](https://github.com/cancervariants/fusor/actions/checks.yaml)
-[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.12708137-blue))](https://doi.org/10.5281/zenodo.12708137)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.12708137-blue)](https://doi.org/10.5281/zenodo.12708137)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FUSOR
 [![image](https://img.shields.io/pypi/l/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![image](https://img.shields.io/pypi/pyversions/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![Actions status](https://github.com/cancervariants/fusor/actions/workflows/checks.yaml/badge.svg)](https://github.com/cancervariants/fusor/actions/checks.yaml)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17343489.svg)](https://doi.org/10.5281/zenodo.17343489)
+[![DOI](https://zenodo.org/badge/17343489.svg)](https://zenodo.org/badge/latestdoi/17343489)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FUSOR
 [![image](https://img.shields.io/pypi/l/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![image](https://img.shields.io/pypi/pyversions/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![Actions status](https://github.com/cancervariants/fusor/actions/workflows/checks.yaml/badge.svg)](https://github.com/cancervariants/fusor/actions/checks.yaml)
-[![DOI](https://zenodo.org/badge/12708137.svg)](https://doi.org/10.5281/zenodo.12708137)
+[![DOI](https://img.shields.io/badge/DOI-10.5281%2Fzenodo.12708137-blue))](https://doi.org/10.5281/zenodo.12708137)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FUSOR
 [![image](https://img.shields.io/pypi/l/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![image](https://img.shields.io/pypi/pyversions/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![Actions status](https://github.com/cancervariants/fusor/actions/workflows/checks.yaml/badge.svg)](https://github.com/cancervariants/fusor/actions/checks.yaml)
-[![DOI](https://zenodo.org/badge/17343489.svg)](https://zenodo.org/badge/latestdoi/17343489)
+[![DOI](https://zenodo.org/badge/12708137.svg)](https://zenodo.org/badge/latestdoi/12708137)
 
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ FUSOR
 [![image](https://img.shields.io/pypi/l/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![image](https://img.shields.io/pypi/pyversions/fusor.svg)](https://pypi.python.org/pypi/fusor)
 [![Actions status](https://github.com/cancervariants/fusor/actions/workflows/checks.yaml/badge.svg)](https://github.com/cancervariants/fusor/actions/checks.yaml)
-[![DOI](https://zenodo.org/badge/12708137.svg)](https://zenodo.org/badge/latestdoi/12708137)
+[![DOI](https://zenodo.org/badge/12708137.svg)](https://doi.org/10.5281/zenodo.12708137)
 
 
 ---


### PR DESCRIPTION
The previous zenodo button pointed to release 0.1.0, and we are now at 0.9.2, so wanted to update