### PR TITLE
docs: update RTD build img

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,7 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-24.04"
   tools:
     python: "3.11"
 


### PR DESCRIPTION
readthedocs just sent out a notice that 20.04 is deprecated