### PR TITLE
build: Update civicpy to 5.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "ga4gh.vrs >=2.3.0,<3.0",
     "biocommons.seqrepo",
     "gene-normalizer ~=0.11.1",
-    "civicpy ~=5.1.1",
+    "civicpy ~=5.3.0",
     "cool-seq-tool ~=0.15.4"
 ]
 dynamic=["version"]


### PR DESCRIPTION
The tests still pass with this update. The analysis notebooks, however, require the version to be 5.1.0 as that was the version that the civicpy cache was generated from.