### PR TITLE
build: Update gene normalizer version to 0.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "pydantic ==2.*",
     "ga4gh.vrs >=2.3.0,<3.0",
     "biocommons.seqrepo",
-    "gene-normalizer ~=0.11.1",
+    "gene-normalizer ~=0.11.2",
     "civicpy ~=5.3.0",
     "cool-seq-tool ~=0.16.0"
 ]


### PR DESCRIPTION
closes #368 

This update in gene normalizer changed the prefixes used in some of the data, so I had to regenerate the database. Once I did this and upgraded the version, the tests passed.