### PR TITLE
build: Update gene normalizer and civicpy versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,8 @@ dependencies = [
     "pydantic ==2.*",
     "ga4gh.vrs >=2.3.0,<3.0",
     "biocommons.seqrepo",
-    "gene-normalizer ~=0.11.2",
-    "civicpy ~=5.3.0",
+    "gene-normalizer ~=0.11.3",
+    "civicpy ~=5.4.0",
     "cool-seq-tool ~=0.16.0"
 ]
 dynamic=["version"]


### PR DESCRIPTION
Update gene-normalizer to `0.11.3` and civicpy to `5.4.0`